### PR TITLE
Convert built-in middleware to raw ASGI, fix inference in use()

### DIFF
--- a/docs/docs/src/content/docs/v1.0/advanced/application-lifecycle.md
+++ b/docs/docs/src/content/docs/v1.0/advanced/application-lifecycle.md
@@ -527,9 +527,13 @@ The `reversed()` iteration builds from innermost to outermost:
 ### ASGIRequestResponseBridge
 
 The two built-in layers above are raw ASGI and are not wrapped. Middleware
-registered with `app.use()` is wrapped in `ASGIRequestResponseBridge` unless it
-was registered with `raw=True`, in which case it too is called directly with
-`(scope, receive, send)`.
+registered with `app.use()` is wrapped in `ASGIRequestResponseBridge` unless
+it is raw, in which case it too is called directly with
+`(scope, receive, send)`. `use()` infers this from the middleware's `__call__`
+signature (see the middleware reference, §2.4) rather than requiring
+`raw=True` to be passed — every one of sillo's own built-ins (sessions, auth,
+CORS, CSRF, rate limiting, security headers, and more) is raw and registers
+with no such flag.
 
 The bridge:
 

--- a/docs/docs/src/content/docs/v1.0/advanced/authentication.md
+++ b/docs/docs/src/content/docs/v1.0/advanced/authentication.md
@@ -19,7 +19,7 @@ Sillo's authentication system is split into three layers that compose cleanly:
 3. **Route gate (`useAuth`)**: per-route enforcement of scheme restrictions,
    permissions, and optional authentication.
 
-The design principle: **the middleware never rejects a request**. It always calls `call_next()`. Rejection is the route gate's job. This lets some routes be public while others require authentication, without the middleware needing to know which is which.
+The design principle: **the middleware never rejects a request**. It always runs the downstream app. Rejection is the route gate's job. This lets some routes be public while others require authentication, without the middleware needing to know which is which.
 
 ```mermaid
 flowchart TD
@@ -31,7 +31,7 @@ flowchart TD
     B1 -->|success| SET[Set scope user/auth/auth_scheme]
     B2 -->|success| SET
     B3 -->|success| SET
-    SET --> NEXT[call_next]
+    SET --> NEXT[downstream app]
     UNAUTH --> NEXT
     NEXT --> ROUTE[Route Handler]
     ROUTE --> GATE{useAuth gate?}
@@ -67,7 +67,8 @@ classDiagram
     class AuthenticationMiddleware {
         +list~AuthenticationBackend~ backends
         +type user_model
-        +dispatch(ctx, call_next)
+        +authenticate(ctx)
+        +__call__(scope, receive, send)
     }
 
     class useAuth {
@@ -184,13 +185,21 @@ Called by the middleware when `authenticate()` raises. The default implementatio
 ### Constructor
 
 ```python
-class AuthenticationMiddleware(BaseMiddleware):
+class AuthenticationMiddleware:
     def __init__(
         self,
         user_model: type[BaseUser] = SimpleUser,
         backend: AuthenticationBackend | list[AuthenticationBackend] = None,
     )
+
+    async def __call__(self, scope, receive, send) -> None: ...
 ```
+
+Plain raw ASGI, not a `BaseMiddleware` subclass — it never touches a
+response, only `scope`, so there was nothing the dispatch bridge's request
+*and* response machinery bought it. `__call__` builds its own `HttpContext`,
+calls `authenticate(ctx)` below to mutate `scope`, then runs the downstream
+app directly.
 
 | Parameter | Default | Purpose |
 |-----------|---------|---------|
@@ -215,7 +224,7 @@ sequenceDiagram
     MW->>MW: scope["user"] = load_user("42")
     MW->>MW: scope["auth"] = "bearerAuth"
     MW->>MW: scope["auth_scheme"] = "bearerAuth"
-    MW->>Handler: call_next()
+    MW->>Handler: downstream app(scope, receive, send)
     Handler-->>Client: Response
 ```
 
@@ -224,32 +233,34 @@ sequenceDiagram
 1. **Iterates backends in order.** Processing stops at the first successful `AuthResult`.
 2. **Sets three scope keys on success:** `"user"`, `"auth"`, `"auth_scheme"`.
 3. **Falls back to `UnauthenticatedUser`** when no backend succeeds. The scope keys `"auth"` and `"auth_scheme"` are set to `None`.
-4. **Always calls `call_next()`**: the middleware never rejects a request.
+4. **Always runs the downstream app**: the middleware never rejects a request.
    Rejection is the route gate's responsibility.
 5. **Catches backend exceptions** and passes them to `handle_exception()`. The middleware continues to the next backend.
 
 ### The `for...else` Pattern
 
-The middleware uses Python's `for...else` construct: the `else` block runs only when the loop completes without `break`. This means the `UnauthenticatedUser` fallback is set exactly when no backend succeeds:
+`authenticate(ctx)` — called from `__call__`, before the downstream app runs
+— uses Python's `for...else` construct: the `else` block runs only when the
+loop completes without `break`. This means the `UnauthenticatedUser` fallback
+is set exactly when no backend succeeds:
 
 ```python
-for backend in self.backends:
-    try:
-        auth_result = await backend.authenticate(ctx)
-        if auth_result.success:
-            ctx.scope["user"] = await self.user_model.load_user(auth_result.identity)
-            ctx.scope["auth"] = auth_result.scope
-            ctx.scope["auth_scheme"] = backend.name
-            break
-    except Exception as e:
-        backend.handle_exception(response, e)
-        continue
-else:
-    ctx.scope["user"] = UnauthenticatedUser()
-    ctx.scope["auth"] = None
-    ctx.scope["auth_scheme"] = None
-
-return await call_next()
+async def authenticate(self, ctx) -> None:
+    for backend in self.backends:
+        try:
+            auth_result = await backend.authenticate(ctx)
+            if auth_result.success:
+                ctx.scope["user"] = await self.user_model.load_user(auth_result.identity)
+                ctx.scope["auth"] = auth_result.scope
+                ctx.scope["auth_scheme"] = backend.name
+                break
+        except Exception as e:
+            backend.handle_exception(ctx, e)
+            continue
+    else:
+        ctx.scope["user"] = UnauthenticatedUser()
+        ctx.scope["auth"] = None
+        ctx.scope["auth_scheme"] = None
 ```
 
 ---
@@ -503,7 +514,7 @@ These are set by the middleware on every request. If the gate has custom backend
 
 ### Why the middleware never rejects
 
-The middleware always calls `call_next()`, even when no backend succeeds. This is intentional: the middleware does not know which routes require authentication. The `useAuth` gate makes that decision. This allows public routes to coexist with authenticated routes in the same application.
+The middleware always runs the downstream app, even when no backend succeeds. This is intentional: the middleware does not know which routes require authentication. The `useAuth` gate makes that decision. This allows public routes to coexist with authenticated routes in the same application.
 
 ### Why `UnauthenticatedUser` instead of `None`
 
@@ -631,12 +642,13 @@ class SignedTimestampBackend(AuthenticationBackend):
 
 ### AuthenticationMiddleware: Complete Internal Flow
 
-Here is the full `dispatch` method with every branch annotated:
+Here is the full `authenticate` method with every branch annotated — the
+half of `__call__` that runs before the downstream app:
 
 ```python
 from sillo import HttpContext
 
-async def dispatch(self, ctx: HttpContext, call_next):
+async def authenticate(self, ctx: HttpContext) -> None:
     # Branch 1: Try each backend in order
     for backend in self.backends:
         try:
@@ -669,8 +681,9 @@ async def dispatch(self, ctx: HttpContext, call_next):
         ctx.scope["auth"] = None
         ctx.scope["auth_scheme"] = None
 
-    # ALWAYS: call the next middleware/handler
-    return await call_next()
+    # Nothing is returned: authentication never answers a request on its
+    # own, it only decides who made it. __call__ runs the downstream app
+    # unconditionally once this returns.
 ```
 
 ### useAuth: Complete Internal Flow

--- a/docs/docs/src/content/docs/v1.0/advanced/extending.md
+++ b/docs/docs/src/content/docs/v1.0/advanced/extending.md
@@ -132,6 +132,13 @@ from `call_next()`, possibly modified, or one it built itself to short-circuit.
 
 ### Step-by-step: Creating custom middleware
 
+> This is a teaching example of the dispatch pattern, not sillo's own rate
+> limiter — `sillo.security.ratelimit.RateLimitMiddleware` is a separate,
+> raw-ASGI implementation (see the middleware architecture reference, §19).
+> Both names existing side by side is intentional: this shows how *you*
+> would write one this way if you needed to, using a name that happens to
+> match.
+
 ```python
 # core/sillo/my_feature/middleware.py
 
@@ -139,7 +146,7 @@ from sillo.middleware.base import BaseMiddleware
 from sillo import HttpContext, text
 
 
-class RateLimitMiddleware(BaseMiddleware):
+class MyRateLimitMiddleware(BaseMiddleware):
     """Example: simple in-memory rate limiter."""
 
     def __init__(self, max_requests: int = 100, window: int = 60, **kwargs):
@@ -172,7 +179,7 @@ class RateLimitMiddleware(BaseMiddleware):
 from sillo import SilloApp
 
 app = SilloApp()
-app.use(RateLimitMiddleware(max_requests=100, window=60))
+app.use(MyRateLimitMiddleware(max_requests=100, window=60))
 ```
 
 ### Ordering

--- a/docs/docs/src/content/docs/v1.0/advanced/http-correctness.md
+++ b/docs/docs/src/content/docs/v1.0/advanced/http-correctness.md
@@ -279,7 +279,7 @@ Accept-family headers before the route handler runs.
 **Source**: [`core/sillo/http/accepts.py:926`](../core/sillo/http/accepts.py)
 
 ```python
-class AcceptsMiddleware(BaseMiddleware):
+class AcceptsMiddleware:
     def __init__(
         self,
         *,
@@ -289,14 +289,22 @@ class AcceptsMiddleware(BaseMiddleware):
         set_vary_header: bool = True,
         store_accepts_info: bool = True,
     ): ...
+
+    async def __call__(self, scope, receive, send) -> None: ...
 ```
 
-**Before `await call_next()`**:
+Plain raw ASGI, not a `BaseMiddleware` subclass: `__call__` builds its own
+`HttpContext`, calls `parse_accepts`, then wraps `send` to call `apply_headers`
+on the `http.response.start` message before forwarding it. Neither of those
+two is a hook a base class prescribes — they're just the two halves of what
+this particular middleware does, named for that.
+
+**`parse_accepts(ctx)`, before the downstream app runs**:
 1. Parses all four headers → stores on `ctx.state.accepts` (full dict) and
    `ctx.state.accepts_parsed` (pre-parsed `AcceptItem` lists)
 2. Records which Accept headers are present for Vary header generation
 
-**After it returns**:
+**`apply_headers(ctx, headers, vary)`, once the response starts**:
 1. Merges recorded Accept headers into the `Vary` response header
 2. If no `Content-Type` is set, negotiates one from the client's Accept header
 
@@ -304,8 +312,8 @@ The factory function `Accepts()` creates a pre-configured instance:
 
 ```python
 # Usage
-app = Sillo()
-app.middleware(Accepts(
+app = SilloApp()
+app.use(Accepts(
     default_content_type="application/json",
     set_vary_header=True,
 ))
@@ -377,8 +385,8 @@ flowchart TD
     B -- Yes --> C{Best type in available_types?}
     C -- Yes --> E
     C -- No --> D["Return 406 JSON:<br/>{error, message, available_types}"]
-    E --> F["Set ctx.negotiated_content_type<br/>Set ctx.negotiated_language"]
-    F --> G[call_next → route handler]
+    E --> F["Set ctx.state.negotiated_content_type<br/>Set ctx.state.negotiated_language"]
+    F --> G[downstream app → route handler]
 
     style D fill:#f96,stroke:#c00
 ```
@@ -407,11 +415,12 @@ and then `response.json(data)`, the `json()` method would create a *new*
 response at 200, silently discarding the 406. This is a subtle API invariant.
 
 **Downstream access**: when negotiation succeeds, the negotiated values are
-stored as dynamic attributes on the request:
+stored on `ctx.state`, which every `HttpContext` built for the same
+connection shares:
 
 ```python
-ctx.negotiated_content_type = best_type
-ctx.negotiated_language = best_language
+ctx.state.negotiated_content_type = best_type
+ctx.state.negotiated_language = best_language
 ```
 
 ---
@@ -529,8 +538,8 @@ def etag_matches(
 `is_fresh()` combines ETag matching with request/response:
 
 ```python
-# core/sillo/http/etag.py:94
-def is_fresh(ctx: HttpContext, weak_compare: bool = True) -> bool:
+# core/sillo/http/etag.py
+def is_fresh(ctx: HttpContext, response: _HasHeaders, weak_compare: bool = True) -> bool:
     current = response.headers.get("etag")
     if not current:
         return False
@@ -539,14 +548,25 @@ def is_fresh(ctx: HttpContext, weak_compare: bool = True) -> bool:
     )
 ```
 
+`response` here is typed as `_HasHeaders`, a small `Protocol` -- not
+`BaseResponse` -- since `ETagMiddleware.finish` calls this with a
+`ResponseHeaders` (§19.2), not a response object; a real `BaseResponse`
+satisfies the same protocol structurally, so nothing that already called this
+with one needs to change.
+
 ### 3.4 ETagMiddleware (304)
 
-The middleware automates ETag computation and 304 responses:
+The middleware automates ETag computation and 304 responses. It is plain raw
+ASGI, not a `BaseMiddleware` subclass — and the one built-in that has to be:
+an ETag is a hash of the response body, and deciding between a 304 and the
+original response needs to know the whole body before either can be sent, so
+`__call__` buffers every `http.response.body` chunk before deciding anything,
+the same way `GZipResponder`'s streaming case (§12.6) does.
 
-**Source**: [`core/sillo/http/etag.py:103`](../core/sillo/http/etag.py)
+**Source**: [`core/sillo/http/etag.py`](../core/sillo/http/etag.py)
 
 ```python
-class ETagMiddleware(BaseMiddleware):
+class ETagMiddleware:
     def __init__(
         self,
         *,
@@ -554,50 +574,64 @@ class ETagMiddleware(BaseMiddleware):
         methods: Iterable[str] = ("GET", "HEAD"),
         override: bool = False,
     ): ...
+
+    async def __call__(self, scope, receive, send) -> None: ...
+    async def finish(self, ctx, start_message, body, send) -> None: ...
 ```
 
 **Response processing flow**:
 
 ```mermaid
 flowchart TD
-    A[Route Handler Produces Response] --> B{HTTP method in allowed methods?}
-    B -- No --> Z[Return response unchanged]
-    B -- Yes --> C{Response has body?}
-    C -- No --> Z
-    C -- Yes --> D{ETag already set AND override=False?}
+    A[Downstream app sends its response] --> B{HTTP method in configured methods?}
+    B -- No --> Z[Forward untouched, no buffering]
+    B -- Yes --> C[Buffer http.response.start + every body chunk]
+    C --> D{ETag already set AND override=False?}
     D -- Yes --> E[Use existing ETag]
-    D -- No --> F["compute_and_set_etag(response, body, weak)"]
+    D -- No --> F["compute_and_set_etag(headers, body, weak)"]
     E --> G{If-None-Match matches ETag?}
     F --> G
-    G -- No --> Z
-    G -- Yes --> H["304 Not Modified<br/>body=b''<br/>content-length=0"]
+    G -- No --> H[Send buffered start + body, unchanged]
+    G -- Yes --> I["Send 304 Not Modified<br/>body=b''<br/>only RFC 9110 §15.4.5 headers"]
 
-    style H fill:#ffa,stroke:#aa0
+    style I fill:#ffa,stroke:#aa0
 ```
 
-**Key implementation detail** (`sillo/http/etag.py`, `dispatch`):
+**Key implementation detail** (`sillo/http/etag.py`, `finish`):
 
 ```python
-from sillo import HttpContext
+from sillo.middleware.response_headers import ResponseHeaders
 
-async def dispatch(self, ctx: HttpContext, call_next):
-    response = await call_next()
-    ...
-    if is_fresh(ctx, response, weak_compare=True):
-        return _not_modified(response)
-    return response
+async def finish(self, ctx, start_message, body: bytes, send) -> None:
+    headers = ResponseHeaders(start_message)
+    if not headers.headers.get("etag") or self.override:
+        compute_and_set_etag(headers, body, weak=self.weak, override=True)
+
+    if is_fresh(ctx, headers, weak_compare=True):
+        # only the headers RFC 9110 §15.4.5 requires a 304 to keep
+        await send({"type": "http.response.start", "status": 304, "headers": [...]})
+        await send({"type": "http.response.body", "body": b""})
+        return
+
+    await send(start_message)
+    await send({"type": "http.response.body", "body": body})
 ```
 
-The 304 is a **new response**, not the original one mutated. That is not a
-style choice: what arrives here is usually a streaming response replaying the
-inner application's body, and `set_body` writes an attribute the streaming path
-never reads. Mutating it changed the status to 304 and the length to 0 while
-the original body still went out behind the headers — a 304 carrying a body,
-declaring a length it does not send, which can desync a keep-alive connection.
-Replacing the response outright is the only way to guarantee nothing follows
+The 304 is sent as **new ASGI messages**, not the buffered ones mutated in
+place — for the same reason the old dispatch-based version had to construct a
+new response object rather than mutate the one it had: a 304 must carry no
+body, and its `Content-Length` must agree with what actually goes out, so
+building the 304 from scratch is the only way to guarantee nothing follows
 the headers.
 
-The 304 it returns:
+This buffering is also a correctness fix, not just a port. Through the old
+dispatch bridge, `call_next()` always handed back a `_StreamingResponse` whose
+`.body` was `b""` regardless of what the downstream app actually sent (§10.1)
+— so `compute_and_set_etag` was always hashing an empty body, and every
+response got the same ETag no matter its content. Buffering the real bytes
+here fixes that: two different responses now get two different ETags.
+
+The 304 it sends:
 - Carries **no body** (saves bandwidth)
 - Still carries the `ETag` header (client can cache it)
 - Drops the headers a 304 must not repeat
@@ -606,7 +640,7 @@ The 304 it returns:
 
 ```python
 # Usage
-app.middleware(ETag(weak=True, methods=("GET", "HEAD")))
+app.use(ETag(weak=True, methods=("GET", "HEAD")))
 ```
 
 ### 3.5 set_response_etag / compute_and_set_etag
@@ -1271,7 +1305,7 @@ sequenceDiagram
 Generates, stores, and propagates request IDs for distributed tracing.
 
 ```python
-class RequestIdMiddleware(BaseMiddleware):
+class RequestIdMiddleware:
     def __init__(
         self,
         *,
@@ -1281,38 +1315,49 @@ class RequestIdMiddleware(BaseMiddleware):
         request_attribute_name: str = "request_id",
         include_in_response: bool = True,
     ): ...
+
+    async def __call__(self, scope, receive, send) -> None: ...
 ```
 
-**The whole flow, in one hook**:
+Plain raw ASGI, not a `BaseMiddleware` subclass: `__call__` builds its own
+`HttpContext`, calls `assign_request_id`, then wraps `send` to call
+`set_response_header` on the `http.response.start` message before forwarding
+it.
+
+**The two halves**:
 
 ```python
-from sillo import HttpContext
+from sillo.middleware.response_headers import ResponseHeaders
 
-async def dispatch(self, ctx: HttpContext, call_next):
+def assign_request_id(self, ctx) -> str:
     if self.force_generate:
         request_id = generate_request_id()       # Always fresh UUID4
     else:
         request_id = get_request_id_from_header(ctx, self.header_name)
         if not request_id:
             request_id = get_or_generate_request_id(ctx, self.header_name)
-    self.request_id = request_id
 
     if self.store_in_request:
         store_request_id_in_request(ctx, request_id, self.request_attribute_name)
 
-    response = await call_next()
+    return request_id
 
-    # After the chain, so the header survives anything downstream set.
-    if response is not None and request_id and self.include_in_response:
-        if not response.headers.get(self.header_name):
-            set_request_id_header(response, request_id, self.header_name)
-
-    return response
+def set_response_header(self, headers: ResponseHeaders, request_id: str) -> None:
+    if not request_id or not self.include_in_response:
+        return
+    if not headers.headers.get(self.header_name):
+        set_request_id_header(headers, request_id, self.header_name)
 ```
 
 The ID is resolved on the way in — so anything downstream can read it off
 `ctx.state` — and stamped on the way out, where it cannot be overwritten by a
-handler that built its own response.
+handler that built its own response. Notice it is not kept anywhere on
+`self`: this middleware instance is shared across every concurrent request
+the application handles, so a value written there would belong to whichever
+request happened to write it last, not the one currently in
+`set_response_header`. Each request's ID lives only in that request's
+`ctx.state` and in `assign_request_id`'s return value, threaded through the
+`send` closure `__call__` builds per request.
 
 **Helper functions** (`core/sillo/http/lifecycle/helpers.py`):
 
@@ -1330,7 +1375,7 @@ handler that built its own response.
 
 ```python
 # Usage
-app.middleware(RequestId(
+app.use(RequestId(
     header_name="X-Request-ID",
     force_generate=False,       # Trust client-supplied IDs
     include_in_response=True,   # Echo back to client

--- a/docs/docs/src/content/docs/v1.0/advanced/middleware.md
+++ b/docs/docs/src/content/docs/v1.0/advanced/middleware.md
@@ -108,14 +108,17 @@ The bridge exists because:
 3. **Composability.** `ASGIRequestResponseBridge` lets both styles mix in a
    single chain without either side knowing about the other.
 
-### 2.4 Registering raw ASGI middleware: `raw=True`
+### 2.4 Registering raw ASGI middleware: inferred, or `raw=True`
 
-`app.use()` takes either style. By default the argument is a dispatch
-middleware — an instance or function taking `(request, response, call_next)` —
-and sillo wraps it in the bridge.
+`app.use()` takes either style, and does not need to be told which: it reads
+`middleware.__call__`'s signature and infers this on its own. Three required
+positional parameters (ASGI's `scope, receive, send`, whatever they happen to
+be named) is read as raw; two (`ctx, call_next`) is read as dispatch. A
+signature too generic to tell — `(*args, **kwargs)` — is left as dispatch, the
+long-standing default, and `use()` raises if that guess turns out to be wrong
+and factory arguments were also passed.
 
-Passing `raw=True` registers a raw ASGI middleware instead. The argument is
-then a **factory**, usually a class, called as
+A raw ASGI middleware is a **factory**, usually a class, called as
 `middleware(next_app, *args, **kwargs)`, and whatever it returns is called with
 `(scope, receive, send)`:
 
@@ -140,13 +143,23 @@ class RequestId:
         await self.app(scope, receive, send_with_id)
 
 
-app.use(RequestId, raw=True, header="x-trace-id")
+app.use(RequestId, header="x-trace-id")  # no raw=True needed
 ```
 
-Positional and keyword arguments after the factory are forwarded to it. They
-are only accepted with `raw=True`; passing them to the dispatch form raises
-`TypeError` rather than dropping them silently, because a dispatch middleware
-is already configured by the time you hand it over.
+`raw=True` (or `raw=False`) still works, and states the shape explicitly
+rather than leaving it to inference — useful for a callable whose signature
+inference can't read, or simply to be unambiguous in code someone else will
+read. Positional and keyword arguments after the factory are forwarded to it,
+whichever way `raw` was decided. They are only accepted for the raw form;
+passing them to the dispatch form raises `TypeError` rather than dropping them
+silently, because a dispatch middleware is already configured by the time you
+hand it over.
+
+A middleware already built as an instance rather than passed as a bare class —
+`app.use(SessionMiddleware(secret_key=...))`, which is how every one of
+sillo's own built-ins is registered — is handled too: `use()` recognises it is
+not a class and binds `next_app` onto it directly (`instance.app = next_app`)
+rather than trying to construct a second one from it.
 
 **When to reach for it.** Raw middleware costs less: nothing is constructed on
 its behalf, where the dispatch form builds an `HttpContext` and a
@@ -155,10 +168,13 @@ a parsed request — header stamping, metrics, routing on `scope["path"]` — an
 use the dispatch form when it does. ASGI middleware written for other
 frameworks generally drops straight in.
 
-sillo's own `ServerErrorMiddleware` and `ExceptionMiddleware` are written this
-way, for exactly that reason: both only care about a request that raised, so
-building a request and a response for every request that did not was pure
-waste.
+sillo's own `ServerErrorMiddleware`, `ExceptionMiddleware`, and every built-in
+in `sillo.security` and `sillo.http` — sessions, authentication, CORS, CSRF,
+rate limiting, security headers, path normalization, request IDs, ETags,
+content negotiation — are written this way, for exactly that reason: none of
+them need a response object handed back to inspect, only a request to read and
+a `send` to intercept, so paying for a bridge on their behalf bought nothing.
+§19 covers what each one's raw `__call__` actually does.
 
 ---
 
@@ -1073,22 +1089,45 @@ silently dropping the message.
 
 ## 13. app.use(): Application-Level Registration
 
-**File:** `core/sillo/application.py` (lines 889 to 933)
+**File:** `core/sillo/application.py` (`use()` starts around line 996; the
+inference helpers `_runtime_call_signature`, `_is_raw_asgi_middleware`, and
+`_rebinding_factory` sit just above the class, starting around line 72)
 
-`SilloApp.use()` registers a dispatch-style middleware at the application level. It
-wraps the middleware in an `ASGIRequestResponseBridge` and inserts it at **position 0**
-of the middleware list.
+`SilloApp.use()` registers a middleware — either style — at the application
+level, and inserts it at **position 0** of the middleware list. Simplified:
 
 ```python
-def use(self, middleware: MiddlewareType) -> None:
+def use(self, middleware, *args, raw=None, **kwargs) -> None:
+    if raw is None:
+        raw = _is_raw_asgi_middleware(middleware)   # §2.4: read off __call__
+
+    if not raw and (args or kwargs):
+        raise TypeError(...)   # dispatch middleware is already configured
+
+    if raw and not inspect.isclass(middleware):
+        raw_factory = _rebinding_factory(middleware)  # bind .app, don't construct
+    else:
+        raw_factory = middleware
+
     if self.auth_user_model is None:
         self.auth_user_model = getattr(middleware, "user_model", None)
 
     self.http_middleware.insert(
         0,
-        Middleware(ASGIRequestResponseBridge, dispatch=middleware),
+        Middleware(raw_factory, *args, **kwargs)
+        if raw
+        else Middleware(ASGIRequestResponseBridge, dispatch=middleware),
     )
 ```
+
+A dispatch middleware is wrapped in `ASGIRequestResponseBridge`, same as
+always. A raw one skips the bridge entirely: if it arrived as a bare class,
+`_build_request_chain` (§5) constructs it the ordinary ASGI way,
+`cls(next_app, *args, **kwargs)`; if it arrived already built — an instance,
+which is how `app.use(SessionMiddleware(secret_key=...))` and every other
+built-in are registered — `_rebinding_factory` wraps it in a one-shot factory
+that sets `.app` on the existing instance and hands the same instance back,
+rather than trying to construct a second one from it.
 
 ### 13.1 Inside-Out Insertion
 
@@ -1150,7 +1189,12 @@ graph TB
 `app.use()` has a side effect: if `self.auth_user_model` hasn't been set yet, it
 checks the middleware for a `user_model` attribute and adopts it. This lets
 `AuthenticationMiddleware` configure the app's auth model without an explicit
-constructor argument.
+constructor argument — provided it is registered the usual way, as an instance
+(`app.use(AuthenticationMiddleware(user_model=MyUser))`). `user_model` is set
+in `__init__`, so `getattr(middleware, "user_model", None)` only finds it on a
+constructed instance; registering the bare class instead
+(`app.use(AuthenticationMiddleware, user_model=MyUser)`) skips this inference, since
+there is no instance yet to read it off.
 
 ### 13.3 The Full Middleware Assembly
 
@@ -1398,10 +1442,14 @@ the local.
 
 ### 18.2 Short-Circuit Pattern
 
+> This is a teaching example of the dispatch pattern, not sillo's own rate
+> limiter — `sillo.security.ratelimit.RateLimitMiddleware` is a separate,
+> raw-ASGI implementation (§19).
+
 ```python
 from sillo import HttpContext, json
 
-class RateLimitMiddleware(BaseMiddleware):
+class MyRateLimitMiddleware(BaseMiddleware):
     def __init__(self, max_requests: int = 100, window: int = 60, **kwargs):
         super().__init__(**kwargs)
         self.max_requests = max_requests
@@ -1508,40 +1556,126 @@ whatever you `return`.
 
 ---
 
-## 19. Security Middleware
+## 19. The Built-In Middleware Are All Raw ASGI
 
-**File:** `core/sillo/middleware/__init__.py`
+**Files:** `sillo/session/middleware.py`, `sillo/auth/middleware.py`,
+`sillo/security/cors/_middleware.py`, `sillo/security/csrf/_middleware.py`,
+`sillo/security/ratelimit/_middleware.py`, `sillo/security/shield.py`,
+`sillo/normalize/middleware.py`, `sillo/http/lifecycle/middleware.py`,
+`sillo/http/etag.py`, `sillo/http/accepts.py`
 
-The middleware package re-exports two security middleware classes:
+None of `SessionMiddleware`, `AuthenticationMiddleware`, `CORSMiddleware`,
+`CSRFMiddleware`, `RateLimitMiddleware`, `Shield`, `NormalizeMiddleware`,
+`RequestIdMiddleware`, `ETagMiddleware`, or the `AcceptsMiddleware` family
+subclass `BaseMiddleware` or write a `dispatch(ctx, call_next)`. Each is a
+plain class — `__init__(self, ...)` setting `self.app = None`, and
+`async def __call__(self, scope, receive, send)` — registered as an
+already-configured instance the way it always has been
+(`app.use(CORSMiddleware(config))`), which §13 covers.
+
+None of them shares a common base beyond that shape. Each names its own
+methods for what it actually does, rather than being forced through a
+`before`/`after` (or `process_request`/`process_response`) contract common to
+all ten — a request-reading step, a response-editing step, or both, whichever
+apply:
+
+| Middleware | Methods |
+|---|---|
+| `SessionMiddleware` | `load_session(ctx)`, `persist_session(ctx, headers)` |
+| `AuthenticationMiddleware` | `authenticate(ctx)` |
+| `CORSMiddleware` | `check_request(ctx)`, `apply_cors_headers(origin, headers)` |
+| `CSRFMiddleware` | `validate(ctx)`, `set_token_cookie(ctx, headers)` |
+| `RateLimitMiddleware` | `check(ctx)`, `set_limit_headers(headers, result)` |
+| `Shield` | `apply_security_headers(headers)` |
+| `NormalizeMiddleware` | `normalize(ctx)` |
+| `RequestIdMiddleware` | `assign_request_id(ctx)`, `set_response_header(headers, id)` |
+| `ETagMiddleware` | `finish(ctx, start_message, body, send)` |
+| `AcceptsMiddleware` family | `parse_accepts(ctx)`, `apply_headers(ctx, headers, vary)`, `negotiate(ctx)` |
+
+### 19.1 Reading the request without the bridge
+
+Every one of them still reads the request the way dispatch code always has —
+`ctx.cookies`, `ctx.headers`, `ctx.origin`, `ctx.method`, `ctx.form` — because
+each builds its own `HttpContext(scope, receive)` directly inside `__call__`.
+That is cheap: an `HttpContext` is just an object wrapping `scope` and
+`receive`, and building one costs nothing like what
+`ASGIRequestResponseBridge` does (§8) to turn a *response* back into
+something inspectable. None of these ten ever need that — none of them
+inspect or replace a response wholesale except by answering before the
+downstream app runs at all (a CORS preflight reply, a CSRF rejection, a 429),
+which any ASGI-callable response (anything `sillo.responses` builds) can do on
+its own: `await response(scope, receive, send)`.
+
+`CSRFMiddleware` is the one exception that needs the request body
+(`_submitted_token` reads a form field), so it builds a `_CachedRequest`
+instead of a plain `HttpContext` — the same buffer-and-replay wrapper
+`ASGIRequestResponseBridge` uses (§9) — and passes its `wrapped_receive` to
+the downstream app so the route handler can still read the same body CSRF
+already consumed.
+
+### 19.2 Editing the response without the bridge
+
+Where a middleware needs to add a header or a cookie to a response it did not
+build — a `Set-Cookie`, a CORS header, an `X-RateLimit-*` — it wraps `send`
+and intercepts the single `http.response.start` message, editing its headers
+list in place before forwarding it, the same pattern `RequestId` in §2.4 (and
+`GZipResponder`, §12) already use.
+
+`sillo.middleware.response_headers.ResponseHeaders` is the shared piece that
+makes this look exactly like editing a response object: `set_header`,
+`set_cookie`, `delete_cookie` and the rest are `BaseResponse`'s own methods,
+defined in `core/sillo/core/http/response.py` and bound to a thin wrapper
+whose `raw_headers` *is* the ASGI message's own headers list. It is a
+shared **utility**, not a shared middleware base class — nothing about it
+dictates a middleware's method names or call order, and a middleware that
+doesn't need it (`AuthenticationMiddleware`, which only ever mutates `scope`)
+never imports it.
+
+`ETagMiddleware` is the one exception that needs the full response body — an
+ETag is a hash of it, and deciding between a 304 and the original response
+needs to know the whole thing before either can be sent — so it buffers every
+`http.response.body` chunk into memory before making that call, the same way
+`GZipResponder`'s streaming case already does (§12.6). This is also a
+correctness fix, not just a port: through the dispatch bridge, `call_next()`
+always handed back a `_StreamingResponse` whose `.body` was `b""` regardless
+of what the downstream app actually sent (§10), so the ETag was always
+computed over an empty body — every response got the same tag no matter its
+content. Buffering the real bytes fixes that.
+
+### 19.3 Registering them
+
+`app.use()`'s signature inference (§2.4) recognises every one of them as raw
+automatically — three required positional parameters on `__call__` — so none
+of the constructor calls below need `raw=True`:
 
 ```python
-from sillo.security.cors import CORSMiddleware
-from sillo.security.csrf import CSRFMiddleware
-from .base import BaseMiddleware
-
-__all__ = ["BaseMiddleware", "CORSMiddleware", "CSRFMiddleware"]
+app.use(SessionMiddleware(secret_key="..."))
+app.use(AuthenticationMiddleware(user_model=User, backend=JWTAuthBackend(...)))
+app.use(CORSMiddleware(CorsConfig(allow_origins=["https://example.com"])))
+app.use(CSRFMiddleware(CSRFConfig(secret_key="...")))
+app.use(RateLimitMiddleware(RateLimitConfig(limit=100, window=60)))
+app.use(Shield())
+app.use(NormalizeMiddleware())
+app.use(RequestIdMiddleware())
+app.use(ETagMiddleware())
+app.use(AcceptsMiddleware())
 ```
 
-These are importable directly from `sillo.middleware`:
+These are all still importable the way they always were —
+`from sillo.security.cors import CORSMiddleware`,
+`from sillo.security.csrf import CSRFMiddleware`, and so on — including from
+the `sillo.middleware` package, which still re-exports `CORSMiddleware` and
+`CSRFMiddleware` alongside `BaseMiddleware`:
 
 ```python
-from sillo.middleware import CORSMiddleware, CSRFMiddleware
+from sillo.middleware import BaseMiddleware, CORSMiddleware, CSRFMiddleware
 ```
 
-### 19.1 Import Ordering Constraint
-
-The `__init__.py` imports `CORSMiddleware` and `CSRFMiddleware` **before**
-`BaseMiddleware` to avoid circular import issues. The security modules import
-`BaseMiddleware` from `sillo.middleware.base` directly, not from the package
-init, which prevents the cycle:
-
-```
-sillo.middleware.__init__  →  imports CORSMiddleware from sillo.security.cors
-sillo.security.cors        →  imports BaseMiddleware from sillo.middleware.base  (NOT from sillo.middleware)
-sillo.middleware.__init__  →  imports BaseMiddleware from .base
-```
-
-If the ordering were reversed, importing `sillo` would fail with `ImportError`.
+Neither `CORSMiddleware` nor `CSRFMiddleware` imports `BaseMiddleware` any
+more — the import-ordering constraint earlier editions of this document
+described here no longer applies, since there is nothing left to cycle
+through. `sillo/middleware/__init__.py` still imports the security classes
+before `.base` out of habit more than necessity at this point.
 
 ---
 
@@ -1624,7 +1758,11 @@ Every dispatch-style middleware goes through `ASGIRequestResponseBridge`, which 
 - A background task for the inner ASGI app
 
 For performance-critical paths (high-throughput APIs), prefer ASGI-native middleware
-that doesn't need the bridge.
+that doesn't need the bridge. None of sillo's own built-ins pay this cost any
+more: sessions, authentication, CORS, CSRF, rate limiting, security headers,
+path normalization, request IDs, ETags, and content negotiation are all raw
+ASGI (§19) — the bridge only runs for dispatch middleware an application
+registers itself.
 
 ### 21.2 GZip Compression Costs
 

--- a/docs/docs/src/content/docs/v1.0/advanced/security.md
+++ b/docs/docs/src/content/docs/v1.0/advanced/security.md
@@ -38,22 +38,32 @@ flowchart TD
 
 ## Security Middleware Architecture
 
-All four extend `BaseMiddleware` from `core/sillo/middleware/base.py`:
+None of the four extends `BaseMiddleware`. Each is plain raw ASGI —
+`__init__(self, ...)` setting `self.app = None`, and
+`async def __call__(self, scope, receive, send)` — registered the way it
+always has been, as an already-configured instance
+(`app.use(Shield(...))`), which `SilloApp.use()` recognises isn't a bare class
+and binds `next_app` onto directly. See the middleware architecture reference
+(§19) for the shared pieces this makes possible without a shared base class:
+`HttpContext` built directly inside `__call__` rather than through the
+dispatch bridge, and `ResponseHeaders` for editing a response's headers in
+place.
 
-```python
-from sillo import HttpContext
+None of them shares a `dispatch`/`call_next` hook, either — each names its
+own methods for what it actually does:
 
-class BaseMiddleware:
-    async def __call__(self, ctx: HttpContext, call_next):
-        return await self.dispatch(ctx, call_next)
+| Middleware | Methods |
+|---|---|
+| `Shield` | `apply_security_headers(headers)` |
+| `CORSMiddleware` | `check_request(ctx)`, `apply_cors_headers(origin, headers)` |
+| `CSRFMiddleware` | `validate(ctx)`, `set_token_cookie(ctx, headers)` |
+| `RateLimitMiddleware` | `check(ctx)`, `set_limit_headers(headers, result)` |
 
-    async def dispatch(self, ctx: HttpContext, call_next):
-        return await call_next()
-```
-
-Each middleware overrides `dispatch`. There is one hook, and the two phases are
-the two sides of the `await`: what runs before `call_next()` sees the request on
-the way in, what runs after it sees the response on the way out.
+The "before" half (reading the request, deciding whether to short-circuit)
+runs in `__call__` itself before the downstream app; the "after" half
+(editing response headers) runs from a closure `__call__` wraps `send` in,
+called when the downstream app's `http.response.start` message passes
+through.
 
 ---
 
@@ -72,7 +82,7 @@ SecurityMiddleware = Shield
 ### Constructor Parameters
 
 ```python
-class Shield(BaseMiddleware):
+class Shield:
     def __init__(
         self,
         # Content Security Policy
@@ -164,9 +174,12 @@ When `ssl_redirect=True`, any HTTP request is redirected to HTTPS:
 ```python
 from sillo import redirect
 
+# Inside __call__, before the downstream app runs
 if self.ssl_redirect and ctx.url.scheme != "https":
     redirect_url = f"https://{self.ssl_host or ctx.url.hostname}{ctx.url.path}"
-    return redirect(url=redirect_url, status_code=301 if self.ssl_permanent else 302)
+    response = redirect(url=redirect_url, status_code=301 if self.ssl_permanent else 302)
+    await response(scope, receive, send)
+    return
 ```
 
 - `ssl_host`: override the hostname (e.g. for load balancers)
@@ -195,6 +208,19 @@ require-trusted-types-for 'script'; trusted-types <policies>
 
 - `hide_server=True` (default): removes the `Server` header
 - `hide_server=False, server_header="MyApp/1.0"`: sets a custom server header
+
+### How the headers actually get applied
+
+`apply_security_headers(headers)` — the `ResponseHeaders` editor for the
+`http.response.start` message — builds a dict from every header the response
+already has, adds Shield's own into it, and writes the result back with
+`headers.set_headers(computed, override_all=True)`. `override_all=True`
+matters: `set_headers()` defaults to appending each entry rather than
+replacing, and `computed` already contains the response's own pre-existing
+headers alongside Shield's additions, so the default would append a second,
+duplicate copy of every header Shield never meant to touch —
+`Content-Type` and `Content-Length` included. This was a real bug in the
+dispatch-based version of Shield, fixed as part of moving it to raw ASGI.
 
 ---
 
@@ -293,8 +319,8 @@ sequenceDiagram
 ### Simple Requests
 
 For non-preflight requests, the middleware:
-1. Calls `call_next()` to process the request
-2. If the origin is allowed, sets `Access-Control-Allow-Origin` on the response
+1. Runs the downstream app (`check_request` found nothing to reject or answer)
+2. Once its response starts, `apply_cors_headers` sets `Access-Control-Allow-Origin` if the origin is allowed
 3. Sets `Access-Control-Allow-Credentials` if configured
 4. Sets `Access-Control-Expose-Headers` if configured
 
@@ -631,52 +657,79 @@ class RateLimitResult:
 **File:** `core/sillo/security/ratelimit/_middleware.py`
 
 ```python
-class RateLimitMiddleware(BaseMiddleware):
+class RateLimitMiddleware:
     def __init__(self, config=None, **kwargs): ...
+
+    async def __call__(self, scope, receive, send) -> None: ...
 ```
 
-**Counting the hit, then stamping the headers:**
+Plain raw ASGI, not a `BaseMiddleware` subclass. `__call__` calls `check`
+before running the downstream app, and wraps `send` to call
+`set_limit_headers` on the `http.response.start` message:
 
 ```python
 from sillo import HttpContext
 
-async def dispatch(self, ctx: HttpContext, call_next):
+async def check(self, ctx: HttpContext):
     key = self.config._key_func(ctx)
     if key is None:
-        return await call_next()  # No key → skip limiting
+        return None  # No key → skip limiting
 
     full_key = f"{self.config.namespace}:{key}"
     try:
-        result = await self._strategy.hit(
+        return await self._strategy.hit(
             self._backend, full_key, self.config.limit,
             self.config.window, cost=self.config.cost,
         )
     except Exception:
         if not self.config.fail_open:
             raise
-        return await call_next()  # Backend failed, fail_open=True
-
-    self._last_result = result
-    if not result.allowed:
-        return self._deny(ctx, result)      # 429, chain stops here
-
-    response = await call_next()
-    self._set_limit_headers(response)
-    return response
+        return None  # Backend failed, fail_open=True
 ```
 
 ```python
-def _set_limit_headers(self, response) -> None:
-    result = self._last_result
-    if response is None or result is None or not self.config.include_headers:
+async def __call__(self, scope, receive, send) -> None:
+    app = self._inner()
+    if scope["type"] != "http":
+        await app(scope, receive, send)
         return
-    response.set_header("X-RateLimit-Limit", str(result.limit), override=True)
-    response.set_header("X-RateLimit-Remaining", str(result.remaining), override=True)
-    response.set_header("X-RateLimit-Reset", str(int(result.reset_at)), override=True)
+
+    ctx = HttpContext(scope, receive)
+    result = await self.check(ctx)
+
+    if result is not None and not result.allowed:
+        response = self._deny(ctx, result)     # 429, downstream app never runs
+        await response(scope, receive, send)
+        return
+
+    async def send_with_limit_headers(message):
+        if message["type"] == "http.response.start":
+            self.set_limit_headers(ResponseHeaders(message), result)
+        await send(message)
+
+    await app(scope, receive, send_with_limit_headers)
+```
+
+```python
+def set_limit_headers(self, headers, result) -> None:
+    if result is None or not self.config.include_headers:
+        return
+    headers.set_header("X-RateLimit-Limit", str(result.limit), override=True)
+    headers.set_header("X-RateLimit-Remaining", str(result.remaining), override=True)
+    headers.set_header("X-RateLimit-Reset", str(int(result.reset_at)), override=True)
 ```
 
 The headers go on only when the request was allowed through. A denied request
 gets its counts from `_deny`, which builds the 429 with them already set.
+
+Notice `result` is a local variable threaded through the `send_with_limit_headers`
+closure, not stored on `self`. It used to be (`self._last_result = result`)
+in the dispatch-based version — a real bug, since one middleware instance
+serves every concurrent request the application handles: a second request's
+result landing on `self` between it being set and `_set_limit_headers`
+reading it back would have stamped the wrong numbers on the first request's
+response. Fixed as part of moving this to raw ASGI, where each request's
+`result` naturally lives in its own `__call__` invocation instead.
 
 **429 response:**
 

--- a/docs/docs/src/content/docs/v1.0/advanced/sessions.md
+++ b/docs/docs/src/content/docs/v1.0/advanced/sessions.md
@@ -24,8 +24,9 @@ classDiagram
     class SessionMiddleware {
         +SessionConfig session_config
         +BaseSessionInterface session_interface
-        +dispatch(ctx, call_next)
-        +_persist(ctx, response)
+        +__call__(scope, receive, send)
+        +load_session(ctx)
+        +persist_session(ctx, headers)
     }
     class SessionConfig {
         -dict _config
@@ -97,20 +98,20 @@ sequenceDiagram
     participant Handler
 
     Client->>Middleware: HTTP Request (Cookie: session_id=abc123)
-    Note over Middleware: dispatch, before call_next
-    Middleware->>Middleware: Read cookie from request
+    Note over Middleware: __call__, before the downstream app runs
+    Middleware->>Middleware: load_session(ctx): read cookie from request
     Middleware->>Backend: create_session("abc123")
     Backend-->>Middleware: Session(interface, "abc123")
     Middleware->>Session: await session.load()
     Session->>Backend: await interface.load(session)
     Backend-->>Session: Populate _session_cache
-    Middleware->>Handler: call_next() (session in scope)
+    Middleware->>Handler: downstream app(scope, receive, send) (session in scope)
 
     Handler->>Session: ctx.session["user_id"] = 42
     Note over Session: modified=True, accessed=True
 
-    Handler-->>Middleware: Response
-    Note over Middleware: dispatch, after call_next
+    Handler-->>Middleware: http.response.start message
+    Note over Middleware: persist_session(ctx, headers), wrapped around send
     Middleware->>Session: Check should_set_cookie
     Middleware->>Session: await session.save()
     Session->>Backend: await interface.save(session)
@@ -453,24 +454,42 @@ Key validation steps:
    `TypeError` if the resolved value is a class rather than an instance, with a
    helpful message showing the correct instantiation pattern.
 
-### dispatch
+### __call__ and load_session
+
+`SessionMiddleware` is plain raw ASGI, not a `BaseMiddleware` subclass:
+`__init__` sets `self.app = None`, and `__call__` takes
+`(scope, receive, send)` directly. It builds its own `HttpContext`, calls
+`load_session` before running the downstream app, and wraps `send` to call
+`persist_session` once the response starts:
 
 ```python
 # core/sillo/session/middleware.py
-async def dispatch(self, ctx: HttpContext, call_next):
+async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+    app = self._inner()
+    if scope["type"] != "http":
+        await app(scope, receive, send)
+        return
+
+    ctx = HttpContext(scope, receive)
+    await self.load_session(ctx)
+
+    async def send_with_session_cookie(message: Message) -> None:
+        if message["type"] == "http.response.start":
+            await self.persist_session(ctx, ResponseHeaders(message))
+        await send(message)
+
+    await app(scope, receive, send_with_session_cookie)
+
+async def load_session(self, ctx: HttpContext) -> None:
     cookie_name = self.session_config.session_cookie_name or "session_id"
     session_key = ctx.cookies.get(cookie_name)
 
     session = self.session_interface.create_session(session_key)
     await session.load()
     ctx.scope["session"] = session
-
-    response = await call_next()
-    await self._persist(ctx, response)
-    return response
 ```
 
-On the way in:
+On the way in, `load_session`:
 
 1. Reads the cookie name from `self.session_config.session_cookie_name`.
 2. Gets `session_key` from `ctx.cookies.get(cookie_name)`.
@@ -478,23 +497,29 @@ On the way in:
 4. Calls `await session.load()` to populate from the backend.
 5. Stores in `ctx.scope["session"]`, which is what `ctx.session` reads.
 
-### _persist
+### persist_session
 
-Everything after the `await` is the write-back, factored into its own method
+The write-back, called from the `send` closure once the response starts,
 because it has three branches:
 
 ```python
 from sillo import HttpContext
+from sillo.middleware.response_headers import ResponseHeaders
 
-async def _persist(self, ctx: HttpContext, response) -> None:
+async def persist_session(self, ctx: HttpContext, headers: ResponseHeaders) -> None:
 ```
+
+`headers` is a `ResponseHeaders` — an editor over the outgoing
+`http.response.start` message's headers, not a response object — but it
+answers to the same `set_cookie`/`delete_cookie` surface a response object
+does, so the branches below read exactly as they would against one.
 
 Three cases:
 
-1. **No session in scope** (line 103): Returns early.
-2. **Empty session that was accessed and modified** (lines 107-115): Calls
+1. **No session in scope**: Returns early.
+2. **Empty session that was accessed and modified**: Calls
    `await session.save()` to let the backend purge its record, then
-   `response.delete_cookie(cookie_name)`. This handles logout. The server-side
+   `headers.delete_cookie(cookie_name)`. This handles logout. The server-side
    store is cleaned up and the cookie is removed.
 3. **should_set_cookie is true** (lines 117-129):
    Calls `await session.save()` to get the cookie value, then sets the cookie

--- a/docs/docs/src/content/docs/v1.0/guides/content-negotiation.md
+++ b/docs/docs/src/content/docs/v1.0/guides/content-negotiation.md
@@ -119,8 +119,8 @@ app.use(
 async def strict_api(ctx: HttpContext):
     # Returns 406 Not Acceptable if the client doesn't accept JSON/XML
     # or doesn't accept English/Spanish
-    negotiated_type = getattr(ctx, "negotiated_content_type", "application/json")
-    negotiated_lang = getattr(ctx, "negotiated_language", "en")
+    negotiated_type = getattr(ctx.state, "negotiated_content_type", "application/json")
+    negotiated_lang = getattr(ctx.state, "negotiated_language", "en")
     return {
         "data": "Strict API response",
         "content_type": negotiated_type,
@@ -469,7 +469,7 @@ def test_stores_accepts_info():
   `default_content_type` is what they get. Make it the format most clients
   expect.
 - **Ordering of middleware.** `Accepts` sets `Content-Type` only when the
-  response has none, after `call_next` returns. Place it where downstream
+  response has none, once the response starts. Place it where downstream
   middleware won't overwrite `Content-Type` afterward.
 - **Language vs content type.** `negotiate_language` only *computes* a
   language; you must set `Content-Language` and select localized content
@@ -507,8 +507,8 @@ app.use(
 
 @app.use
 async def content_negotiation_logger(ctx: HttpContext, call_next):
-    negotiated_type = getattr(ctx, "negotiated_content_type", "unknown")
-    negotiated_lang = getattr(ctx, "negotiated_language", "unknown")
+    negotiated_type = getattr(ctx.state, "negotiated_content_type", "unknown")
+    negotiated_lang = getattr(ctx.state, "negotiated_language", "unknown")
     print(f"Content-Type: {negotiated_type}, Language: {negotiated_lang}")
     return await call_next()
 ```

--- a/docs/docs/src/content/docs/v1.0/guides/cors.md
+++ b/docs/docs/src/content/docs/v1.0/guides/cors.md
@@ -245,7 +245,7 @@ app.use(CORSMiddleware(config=cors_config))
 
 ##  How CORS is enforced
 
-`CORSMiddleware` runs before `call_next` for every request:
+`CORSMiddleware` checks every request before the downstream app runs:
 
 1. If there is no `Origin` header, the request is same-origin: the middleware
    does nothing and the request proceeds.

--- a/docs/docs/src/content/docs/v1.0/guides/csrf.md
+++ b/docs/docs/src/content/docs/v1.0/guides/csrf.md
@@ -248,7 +248,7 @@ app.use(CSRFMiddleware(config=csrf_config))
 
 ##  How a request is checked
 
-`CSRFMiddleware.dispatch` runs this sequence before `call_next`, for every request (only when `enabled=True`):
+`CSRFMiddleware.validate` runs this sequence before the downstream app, for every request (only when `enabled=True`):
 
 1. Generate a fresh signed token and stash it on `ctx.state.csrf_token`.
 2. If the method is in `safe_methods` (`GET`, `HEAD`, `OPTIONS` by default), allow the request through.
@@ -259,7 +259,7 @@ app.use(CSRFMiddleware(config=csrf_config))
    - The submitted token must match the cookie token.
 4. Any failure (missing cookie, missing token, mismatch) returns **`403`** and clears the CSRF cookie.
 
-On the way out, after `call_next` returns, it sets the `csrftoken` cookie so the next
+On the way out, once the response starts, `set_token_cookie` sets the `csrftoken` cookie so the next
 request can present a matching header. The cookie is `HttpOnly` by default, so
 JavaScript cannot read it. The token must travel in the header (or form field),
 which is what makes the pattern resistant to cross-site forgery.

--- a/docs/docs/src/content/docs/v1.0/guides/security.md
+++ b/docs/docs/src/content/docs/v1.0/guides/security.md
@@ -31,10 +31,11 @@ With no arguments, `Shield` applies a strict default policy: CSP locked to `'sel
 
 ##  How Shield applies headers
 
-`Shield` is a `BaseMiddleware`. After `call_next` returns it writes each configured
-header onto the response before it leaves the stack. Because it runs late in
-the chain, headers are present even on error responses and redirects, unless a
-later middleware overrides them.
+`Shield` is plain raw ASGI, not a `BaseMiddleware` subclass. It wraps `send`
+and, once the downstream app's response starts, writes each configured header
+onto it before forwarding it on. Because it runs late in the chain, headers
+are present even on error responses and redirects, unless a later middleware
+overrides them.
 
 Defaults that are safe to change:
 

--- a/docs/docs/src/content/docs/v1.0/guides/session-auth.md
+++ b/docs/docs/src/content/docs/v1.0/guides/session-auth.md
@@ -327,7 +327,7 @@ async def logout(ctx: HttpContext):
 ```
 
 `clear()` is the whole logout. It marks the session emptied *and* deleted, and
-`SessionMiddleware`, after `call_next` returns, hands the emptied session to the backend
+`SessionMiddleware`, once the response starts, hands the emptied session to the backend
 before dropping the cookie, so a server-backed store purges its record rather
 than leaving a key that anyone holding the old cookie could still present.
 

--- a/docs/docs/src/content/docs/v1.0/guides/url-normalization.md
+++ b/docs/docs/src/content/docs/v1.0/guides/url-normalization.md
@@ -34,7 +34,7 @@ With the default `REDIRECT_REMOVE`, a request to `/users/` is answered with a **
 
 ##  How a request is normalized
 
-`NormalizeMiddleware.dispatch` runs this sequence before `call_next`, for every request:
+`NormalizeMiddleware.normalize` runs this sequence before the downstream app, for every request:
 
 1. **Skip** paths that contain `.`, `?`, or `#` (files, queries, fragments):
    these are never rewritten.
@@ -42,7 +42,7 @@ With the default `REDIRECT_REMOVE`, a request to `/users/` is answered with a **
 3. **Lowercase** the path when `normalize_case=True`.
 4. **Apply the slash action.** Either mutate `ctx.scope["path"]` in place
    (silent modes) or return a `301`/`302` redirect (redirect modes).
-5. Otherwise call `await call_next()` unchanged.
+5. Otherwise let the request through to the downstream app unchanged.
 
 Because silent modes rewrite `ctx.scope["path"]`, the router matches the cleaned path with no extra round trip. Redirect modes send the client to the canonical URL and stop there.
 
@@ -161,8 +161,8 @@ def test_silent_remove():
 
 ##  Works with
 
-- **Routing.** Normalization runs before `call_next`, so the router always
-  sees the canonical path. Place `Normalize` early in the middleware chain.
+- **Routing.** Normalization runs before the downstream app, so the router
+  always sees the canonical path. Place `Normalize` early in the middleware chain.
 - **Static files.** Asset paths are auto-skipped, so normalization never
   interferes with `static()` mounts.
 - **Security middleware.** Run `Normalize` before CSRF/Shield so they evaluate

--- a/sillo/application.py
+++ b/sillo/application.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
     from sillo.core.http import HttpContext
     from sillo.users import BaseUser
 
+import inspect
 import json
 import warnings
 
@@ -66,6 +67,124 @@ except ImportError:
     uvicorn = None  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
 
 allowed_methods_default = ["get", "post", "delete", "put", "patch", "options"]
+
+
+def _runtime_call_signature(
+    middleware: MiddlewareType | MiddlewareFactory | ASGIApp,
+) -> inspect.Signature | None:
+    """Return the signature that governs how `middleware` is actually called.
+
+    A class registered with `use()` is a *factory*: sillo constructs an
+    instance of it (`cls(next_app, *args, **kwargs)`) and it is that
+    instance's `__call__` -- not the class's `__init__`, which is what
+    `inspect.signature` reads for a class by default -- that runs per
+    request. `getattr(cls, "__call__", None)` is used rather than
+    `cls.__dict__.get("__call__")` so an `__call__` inherited from a base
+    class (as opposed to one only ever present on `object`, i.e. not
+    overridden at all) is found by walking the MRO the same way Python does
+    when it actually calls the instance.
+
+    Anything that isn't a class -- an instance, a bound method, a plain
+    function, a `functools.partial` -- is called directly as-is, so its own
+    signature is what matters. `inspect.unwrap` strips any `functools.wraps`
+    decoration first so a decorated middleware doesn't get misread as
+    `(*args, **kwargs)`.
+
+    Returns `None` when no such signature can be determined at all, which
+    callers must treat as "no structural signal either way."
+    """
+    if inspect.isclass(middleware):
+        # Not the `hasattr(x, "__call__")` anti-pattern `callable()` replaces:
+        # the object fetched here is inspected for its signature, not just
+        # tested for truthiness, and `callable(middleware)` would answer
+        # about the class itself (always true; classes are callable) rather
+        # than about what its *instances* -- what `use()` actually ends up
+        # calling -- will be.
+        target = getattr(middleware, "__call__", None)  # noqa: B004
+        if target is None or target is object.__call__:
+            return None
+    elif callable(middleware):
+        target = middleware
+    else:
+        return None
+
+    try:
+        return inspect.signature(inspect.unwrap(target))
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_raw_asgi_middleware(
+    middleware: MiddlewareType | MiddlewareFactory | ASGIApp,
+) -> bool:
+    """Guess whether `middleware` is a raw ASGI factory rather than dispatch.
+
+    The two calling conventions `use()` accepts -- ASGI's `(scope, receive,
+    send)` and sillo's dispatch `(ctx, call_next)` -- are both called with
+    every argument positional and none defaulted. That makes the *count* of
+    required positional parameters the signal to read, not what their author
+    happened to name them: three is ASGI, two is dispatch, regardless of
+    whether those three are spelled `scope, receive, send` or something else
+    entirely.
+
+    A signature that swallows everything generically (`*args, **kwargs`), or
+    whose count matches neither convention, carries no structural signal in
+    either direction. That is left as dispatch -- the pre-existing default --
+    and `use()` separately raises if that guess turns out to be wrong and
+    factory arguments were also passed, rather than silently misrouting them.
+    """
+    sig = _runtime_call_signature(middleware)
+    if sig is None:
+        return False
+
+    positional_kinds = (
+        inspect.Parameter.POSITIONAL_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    )
+    params = [p for p in sig.parameters.values() if p.name not in ("self", "cls")]
+    has_var_positional = any(p.kind is inspect.Parameter.VAR_POSITIONAL for p in params)
+    required_positional = [
+        p
+        for p in params
+        if p.kind in positional_kinds and p.default is inspect.Parameter.empty
+    ]
+
+    if has_var_positional:
+        return False
+    if len(required_positional) == 3:
+        return True
+    if len(required_positional) == 2:
+        return False
+    return False
+
+
+def _rebinding_factory(instance: ASGIApp) -> MiddlewareFactory:
+    """Wrap an already-constructed raw ASGI middleware as a one-shot factory.
+
+    `_build_request_chain` calls every raw entry as `cls(next_app, *args,
+    **kwargs)` -- the ASGI convention, which assumes `cls` is still waiting
+    to be built. `app.use(SessionMiddleware(secret_key=...))` and every other
+    built-in registered the same way pass an instance instead, already
+    configured and with nowhere to put `next_app` except by setting `.app` on
+    it directly -- which each of those sets to `None` at construction for
+    exactly this. Third-party raw ASGI middleware registered the same way is
+    expected to do likewise; one without a settable `.app` fails here with an
+    `AttributeError` naming the instance, which is a clearer signal than the
+    `TypeError` calling it as a factory would have raised instead.
+
+    `instance` is typed as the `ASGIApp` it already is, not the factory it is
+    about to be wrapped as -- `.app` is set on it with `setattr` rather than
+    attribute access because nothing in the `ASGIApp` shape (just `(scope,
+    receive, send) -> Awaitable`) promises that attribute exists; the
+    `AttributeError` this raises when it does not is the point.
+    """
+
+    def factory(app: ASGIApp) -> ASGIApp:
+        setattr(instance, "app", app)  # noqa: B010
+        return instance
+
+    return cast(MiddlewareFactory, factory)
+
 
 logger = create_logger("sillo")
 lifespan_manager = Callable[
@@ -877,7 +996,7 @@ class SilloApp:
     def use(
         self,
         middleware: Annotated[
-            MiddlewareType | MiddlewareFactory,
+            MiddlewareType | MiddlewareFactory | ASGIApp,
             Doc(
                 "A callable middleware function that processes requests and responses."
             ),
@@ -887,16 +1006,20 @@ class SilloApp:
             Doc("Positional arguments forwarded to a `raw=True` middleware factory."),
         ],
         raw: Annotated[
-            bool,
+            bool | None,
             Doc(
                 "Treat `middleware` as a raw ASGI middleware factory, called as "
                 "`middleware(next_app, *args, **kwargs)`, instead of a dispatch "
-                "function."
+                "function. Left as `None`, sillo infers this from "
+                "`middleware`'s `__call__` signature: three required "
+                "positional parameters (ASGI's `scope, receive, send`, "
+                "whatever they're named) is raw, two (`ctx, call_next`) is "
+                "dispatch. Pass `True`/`False` to state it explicitly instead."
             ),
-        ] = False,
+        ] = None,
         **kwargs: Annotated[
             Any,
-            Doc("Keyword arguments forwarded to a `raw=True` middleware factory."),
+            Doc("Keyword arguments forwarded to a raw middleware factory."),
         ],
     ) -> None:
         """
@@ -906,40 +1029,45 @@ class SilloApp:
         modifications to requests before they reach the route handler and responses
         before they are sent back to the client.
 
-        Two forms are accepted.
+        Two forms are accepted, and sillo tells them apart on its own -- see
+        `raw` below -- so nothing needs to be passed to say which one this is,
+        in the common case.
 
-        The default is sillo's dispatch form: an instance, or a plain function,
-        taking `(ctx, call_next)`. sillo builds the `HttpContext` for it and
-        turns the rest of the chain into something awaitable. That is
-        convenient, and it costs a context object and a background task per
-        layer per request. Return a response to end the chain early.
+        sillo's dispatch form is an instance, or a plain function, taking
+        `(ctx, call_next)`. sillo builds the `HttpContext` for it and turns
+        the rest of the chain into something awaitable. That is convenient,
+        and it costs a context object and a background task per layer per
+        request. Return a response to end the chain early.
 
-        Passing `raw=True` registers a raw ASGI middleware instead. The
-        argument is then a *factory* — usually a class — invoked as
-        `middleware(next_app, *args, **kwargs)`, and whatever it returns is
-        called with `(scope, receive, send)`. Nothing is built on its behalf,
-        so it is the cheaper form and the one to reach for when the middleware
-        does not need a parsed request; it is also how sillo's own
+        A raw ASGI middleware is a *factory* — usually a class — invoked as
+        `middleware(next_app, *args, **kwargs)`, whose `__call__` takes
+        `(scope, receive, send)`. Nothing is built on its behalf, so it is the
+        cheaper form and the one to reach for when the middleware does not
+        need a parsed request; it is also how sillo's own
         `ServerErrorMiddleware` and `ExceptionMiddleware` are written. ASGI
-        middleware from other frameworks generally drops straight in.
+        middleware from other frameworks generally drops straight in this way.
 
         Args:
-            middleware: With `raw=False`, a callable taking an `HttpContext`
-                and a `call_next` callable, returning a response.
-                With `raw=True`, a factory taking the next ASGI application as
-                its first argument and returning an ASGI application.
-            *args: Positional arguments for the factory. `raw=True` only.
-            raw: Whether `middleware` is a raw ASGI middleware factory.
-            **kwargs: Keyword arguments for the factory. `raw=True` only.
+            middleware: A callable taking an `HttpContext` and a `call_next`
+                callable and returning a response (dispatch form), or a
+                factory taking the next ASGI application as its first
+                argument and returning an ASGI application (raw form).
+            *args: Positional arguments for the factory. Raw ASGI middleware
+                only.
+            raw: Whether `middleware` is a raw ASGI middleware factory. Left
+                as `None`, this is inferred from `middleware`'s signature.
+            **kwargs: Keyword arguments for the factory. Raw ASGI middleware
+                only.
 
         Returns:
             None
 
         Raises:
-            TypeError: If extra arguments are passed without `raw=True`. The
-                dispatch form takes a middleware that is already configured, so
-                there is nowhere for them to go and silently dropping them
-                would leave the middleware running on its defaults.
+            TypeError: If extra arguments are passed for middleware that
+                resolves to the dispatch form. The dispatch form takes a
+                middleware that is already configured, so there is nowhere
+                for them to go and silently dropping them would leave the
+                middleware running on its defaults.
 
         Example:
             ```python
@@ -951,7 +1079,8 @@ class SilloApp:
             app.use(logging_middleware)
 
 
-            # raw ASGI form
+            # raw ASGI form -- detected automatically from its three-argument
+            # __call__, no raw=True needed
             class RequestId:
                 def __init__(self, app, header: str = "x-request-id"):
                     self.app = app
@@ -968,15 +1097,34 @@ class SilloApp:
 
                     await self.app(scope, receive, send_with_id)
 
-            app.use(RequestId, raw=True, header="x-trace-id")
+            app.use(RequestId, header="x-trace-id")
             ```
         """
+        if raw is None:
+            raw = _is_raw_asgi_middleware(middleware)
+
         if not raw and (args or kwargs):
             raise TypeError(
                 "use() forwards extra arguments only to raw ASGI middleware. "
-                "Pass raw=True to have them handed to the factory, or "
-                "configure the middleware before registering it."
+                "This middleware's __call__ was read as the dispatch form "
+                "(ctx, call_next), so pass raw=True if it is meant to be a "
+                "raw ASGI factory, or configure the middleware before "
+                "registering it."
             )
+
+        if raw and not inspect.isclass(middleware):
+            if args or kwargs:
+                raise TypeError(
+                    "use() forwards extra arguments only when constructing a "
+                    "raw ASGI middleware, and this one is already "
+                    "constructed. Pass its options to the instance itself, "
+                    f"not to use(): {middleware!r}"
+                )
+            raw_factory: MiddlewareFactory = _rebinding_factory(
+                cast(ASGIApp, middleware)
+            )
+        else:
+            raw_factory = cast(MiddlewareFactory, middleware)
 
         # Authentication can be configured two ways: SilloApp(auth_user_model=…)
         # or AuthenticationMiddleware(user_model=…) passed to use(). Both name
@@ -990,11 +1138,14 @@ class SilloApp:
             0,
             # Raw middleware is the factory itself: the chain builder calls
             # `cls(next_app, *args, **kwargs)`, which is exactly the ASGI
-            # convention, so no wrapper is involved at all. `raw=True` is the
-            # caller stating which half of the union they passed, and nothing
-            # in the type system carries that from the flag to the value, so
-            # the cast is where that claim is recorded.
-            Middleware(cast(MiddlewareFactory, middleware), *args, **kwargs)
+            # convention, so no wrapper is involved at all -- an
+            # already-constructed instance is wrapped in a one-shot factory
+            # above so the same call still works. `raw` is the caller's (or
+            # the inference's) claim about which half of the union
+            # `middleware` is, and nothing in the type system carries that
+            # from the flag to the value, so the cast is where that claim is
+            # recorded.
+            Middleware(raw_factory, *args, **kwargs)
             if raw
             else Middleware(ASGIRequestResponseBridge, dispatch=middleware),
         )

--- a/sillo/auth/middleware.py
+++ b/sillo/auth/middleware.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import typing
 from typing import Annotated
 
 from typing_extensions import Doc
@@ -8,13 +7,13 @@ from typing_extensions import Doc
 from sillo import logging
 from sillo.auth.backend import AuthenticationBackend
 from sillo.core.http import HttpContext
-from sillo.middleware.base import BaseMiddleware
+from sillo.types import ASGIApp, Receive, Scope, Send
 from sillo.users import BaseUser, SimpleUser, UnauthenticatedUser
 
 logger = logging.create_logger(__name__)
 
 
-class AuthenticationMiddleware(BaseMiddleware):
+class AuthenticationMiddleware:
     """Middleware responsible for handling user authentication on every request.
 
     This middleware intercepts incoming HTTP requests, processes them through
@@ -61,6 +60,11 @@ class AuthenticationMiddleware(BaseMiddleware):
         a list. If a single backend is provided it is wrapped in a list for
         uniform iteration during request processing.
 
+        This is registered as a configured instance --
+        `app.use(AuthenticationMiddleware(user_model=...))` -- and `use()`
+        binds the next ASGI application onto it afterwards; there is no
+        `app` argument to pass here.
+
         Args:
             user_model: The user model class to use for loading authenticated
                 users. Must implement the ``BaseUser`` protocol including a
@@ -77,6 +81,11 @@ class AuthenticationMiddleware(BaseMiddleware):
             No exceptions are raised during initialisation. Invalid backend
                 types will surface as errors during request processing.
         """
+        # `app` is bound on afterwards by `use()`, not passed here: this is
+        # registered as a configured instance --
+        # `app.use(AuthenticationMiddleware(user_model=...))`.
+        self.app: ASGIApp | None = None
+
         # Narrowed on the backend type rather than on `list`, so the empty
         # default lands as an empty list. Wrapping it produced `[None]`,
         # whose first failure called `None.handle_exception` inside the
@@ -88,15 +97,44 @@ class AuthenticationMiddleware(BaseMiddleware):
             self.backends = list(backend)
         self.user_model = user_model
 
-    async def dispatch(
+    def _inner(self) -> ASGIApp:
+        """Return the inner application, refusing to serve without one.
+
+        ``app`` is bound by ``use()`` after construction, not passed here --
+        so a middleware never registered still names its own mistake instead
+        of surfacing as ``'NoneType' object is not callable``.
+        """
+        if self.app is None:
+            raise RuntimeError(
+                "AuthenticationMiddleware was constructed without an inner "
+                "application and cannot serve requests. Register it with "
+                "app.use(AuthenticationMiddleware(...))."
+            )
+        return self.app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Authenticate the request, then run the downstream app.
+
+        Non-HTTP connections (websocket, lifespan) are forwarded untouched --
+        there is no request here to authenticate.
+        """
+        app = self._inner()
+        if scope["type"] != "http":
+            await app(scope, receive, send)
+            return
+
+        ctx = HttpContext(scope, receive)
+        await self.authenticate(ctx)
+        await app(scope, receive, send)
+
+    async def authenticate(
         self,
         ctx: Annotated[
             HttpContext,
             Doc("The context for this request, carrying the credentials."),
         ],
-        call_next: typing.Callable[..., typing.Awaitable[typing.Any]],
     ) -> None:
-        """Process an incoming request through all authentication backends.
+        """Run this request through all authentication backends.
 
         Iterates through each backend in order, attempting to authenticate
         the request. If a backend successfully authenticates the user, the
@@ -113,19 +151,10 @@ class AuthenticationMiddleware(BaseMiddleware):
             ctx: The context for this request, carrying credentials such as
                 authorization headers, cookies, or session data that backends
                 use to identify the caller.
-            call_next: An async callable representing the next middleware or
-                route handler in the pipeline. Called after authentication
-                processing is complete, regardless of whether a user was
-                successfully authenticated.
-
-        Returns:
-            The return value of ``call_next()``, which is the result of the
-                downstream middleware/handler processing chain.
 
         Raises:
             No exceptions are raised by this method. Backend exceptions are
-                caught and handled internally. Exceptions from ``call_next``
-                propagate normally to the caller.
+                caught and handled internally.
         """
         # Try each backend until one successfully authenticates the user
         for backend in self.backends:
@@ -155,5 +184,3 @@ class AuthenticationMiddleware(BaseMiddleware):
             ctx.scope["user"] = UnauthenticatedUser()
             ctx.scope["auth"] = None
             ctx.scope["auth_scheme"] = None
-
-        return await call_next()

--- a/sillo/http/accepts.py
+++ b/sillo/http/accepts.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from typing import Any
 
 from sillo.core.http import HttpContext
-from sillo.middleware.base import BaseMiddleware
+from sillo.middleware.response_headers import ResponseHeaders
 from sillo.responses import json
+from sillo.types import ASGIApp, Message, Receive, Scope, Send
 
 
 class AcceptItem:
@@ -922,7 +923,7 @@ def get_best_accepted_language(
     return available_languages[0] if available_languages else None
 
 
-class AcceptsMiddleware(BaseMiddleware):
+class AcceptsMiddleware:
     """Middleware that parses and stores Accept-family header information.
 
     Intercepts incoming requests to parse all Accept-family headers and
@@ -968,8 +969,8 @@ class AcceptsMiddleware(BaseMiddleware):
             store_accepts_info: If ``True``, parses and stores Accept data
                 on ``ctx.state`` for downstream handler access.
                 Defaults to ``True``.
-            **kwargs: Additional keyword arguments passed to the parent
-                :class:`~sillo.middleware.base.BaseMiddleware` constructor.
+            **kwargs: Additional keyword arguments, accepted but ignored, for
+                compatibility with generic middleware configuration patterns.
 
         Returns:
             None. This is a constructor and does not return a value.
@@ -977,35 +978,56 @@ class AcceptsMiddleware(BaseMiddleware):
         Raises:
             No exceptions are raised during initialization.
         """
-        super().__init__(**kwargs)
+        # Bound on afterwards by `use()`: this is registered as a configured
+        # instance, `app.use(AcceptsMiddleware(...))`.
+        self.app: ASGIApp | None = None
         self.default_content_type = default_content_type
         self.default_language = default_language
         self.default_charset = default_charset
         self.set_vary_header = set_vary_header
         self.store_accepts_info = store_accepts_info
-        self.vary: list[str] = []
 
-    async def dispatch(self, ctx: HttpContext, call_next: Any) -> Any:
-        """Parse the Accept-family headers, then set Vary on the reply.
+    def _inner(self) -> ASGIApp:
+        """Return the inner application, refusing to serve without one."""
+        if self.app is None:
+            raise RuntimeError(
+                f"{type(self).__name__} was constructed without an inner "
+                f"application and cannot serve requests. Register it with "
+                f"app.use({type(self).__name__}(...))."
+            )
+        return self.app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Parse the Accept-family headers, then set Vary on the reply."""
+        app = self._inner()
+        if scope["type"] != "http":
+            await app(scope, receive, send)
+            return
+
+        ctx = HttpContext(scope, receive)
+        vary = self.parse_accepts(ctx)
+
+        async def send_with_negotiated_headers(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                self.apply_headers(ctx, ResponseHeaders(message), vary)
+            await send(message)
+
+        await app(scope, receive, send_with_negotiated_headers)
+
+    def parse_accepts(self, ctx: HttpContext) -> list[str]:
+        """Parse the Accept-family headers, returning which ones were present.
 
         When ``store_accepts_info`` is enabled, parses all four Accept-family
         headers and stores both a comprehensive info dictionary and a
-        pre-parsed dictionary on the request state. When ``set_vary_header``
-        is enabled, records which Accept-family headers are present so that
-        appropriate ``Vary`` headers can be set on the response.
+        pre-parsed dictionary on the request state.
 
         Args:
             ctx: The context whose headers will be inspected and parsed.
-            call_next: An async callable that invokes the next middleware
-                or request handler in the processing chain.
 
         Returns:
-            The response from the rest of the chain, with ``Vary`` and
-            ``Content-Type`` set as configured.
-
-        Raises:
-            No exceptions are raised directly; any exceptions from the
-            downstream handler are propagated unchanged.
+            The Accept-family header names present on this request, in the
+            order checked -- what ``apply_headers`` needs to build ``Vary``.
+            Empty when ``set_vary_header`` is off.
         """
         if self.store_accepts_info:
             accepts_info = get_accepts_info(ctx)
@@ -1022,20 +1044,22 @@ class AcceptsMiddleware(BaseMiddleware):
                     ctx.headers.get("Accept-Encoding", "")
                 ),
             }
+
+        vary: list[str] = []
         if self.set_vary_header:
             if ctx.headers.get("Accept"):
-                self.vary.append("Accept")
+                vary.append("Accept")
             if ctx.headers.get("Accept-Language"):
-                self.vary.append("Accept-Language")
+                vary.append("Accept-Language")
             if ctx.headers.get("Accept-Charset"):
-                self.vary.append("Accept-Charset")
+                vary.append("Accept-Charset")
             if ctx.headers.get("Accept-Encoding"):
-                self.vary.append("Accept-Encoding")
+                vary.append("Accept-Encoding")
+        return vary
 
-        response = await call_next()
-        return self._decorate(ctx, response)
-
-    def _decorate(self, ctx: HttpContext, response: Any) -> Any:
+    def apply_headers(
+        self, ctx: HttpContext, headers: ResponseHeaders, vary: list[str]
+    ) -> None:
         """Set the Vary and Content-Type headers on the outgoing response.
 
         If any Accept-family headers were detected in the request, adds
@@ -1045,38 +1069,29 @@ class AcceptsMiddleware(BaseMiddleware):
         header or falls back to the configured default.
 
         Args:
-            request: The context used to look up Accept headers for
-                content negotiation.
-            response: The outgoing response whose headers will be updated
-                before sending to the client.
-
-        Returns:
-            The response, with ``Vary`` and ``Content-Type`` headers updated
-            as appropriate.
-
-        Raises:
-            No exceptions are raised during response processing.
+            ctx: The context used to look up Accept headers for content
+                negotiation.
+            headers: An editor over the outgoing response's headers.
+            vary: The Accept-family header names this request carried, from
+                ``parse_accepts``.
         """
-        if response is None:
-            return None
-        if self.vary:
-            existing_vary = response.headers.get("Vary")
-            response.set_header(
-                "Vary", create_vary_header(existing_vary, self.vary), override=True
+        if vary:
+            existing_vary = headers.headers.get("Vary")
+            headers.set_header(
+                "Vary", create_vary_header(existing_vary, vary), override=True
             )
-        if not response.headers.get("Content-Type") and self.default_content_type:
+        if not headers.headers.get("Content-Type") and self.default_content_type:
             accept_header = ctx.headers.get("Accept")
             if accept_header:
                 negotiated_type = negotiate_content_type(
                     accept_header, [self.default_content_type]
                 )
                 if negotiated_type:
-                    response.set_header("Content-Type", negotiated_type, override=True)
+                    headers.set_header("Content-Type", negotiated_type, override=True)
             else:
-                response.set_header(
+                headers.set_header(
                     "Content-Type", self.default_content_type, override=True
                 )
-        return response
 
 
 def Accepts(
@@ -1254,29 +1269,45 @@ class StrictContentNegotiationMiddleware(ContentNegotiationMiddleware):
         self.available_types = available_types
         self.available_languages = available_languages or ["en"]
 
-    async def dispatch(self, ctx: HttpContext, call_next: Any) -> Any:
-        """Enforce strict content negotiation before running the chain.
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Enforce strict content negotiation, then run the app.
+
+        This replaces :meth:`AcceptsMiddleware.__call__` entirely rather than
+        running alongside it -- strict negotiation answers 406 on its own
+        terms, and has never also stamped the ``Vary``/``Content-Type``
+        headers the lenient base class does.
+        """
+        app = self._inner()
+        if scope["type"] != "http":
+            await app(scope, receive, send)
+            return
+
+        ctx = HttpContext(scope, receive)
+        rejection = self.negotiate(ctx)
+        if rejection is not None:
+            await rejection(scope, receive, send)
+            return
+
+        await app(scope, receive, send)
+
+    def negotiate(self, ctx: HttpContext) -> Any | None:
+        """Negotiate content type and language, or reject the request.
 
         Negotiates the best content type and language for the request.
         If the client cannot accept any of the available content types
         and an Accept header was present, returns an HTTP 406 response.
-        Otherwise stores the negotiated values on the request object
-        and proceeds to the next handler.
+        Otherwise stores the negotiated values on the request object.
 
         Args:
             ctx: The context whose Accept headers will be used for strict
                 negotiation.
-            call_next: An async callable that invokes the next middleware
-                or request handler in the processing chain.
 
         Returns:
-            Either an HTTP 406 response if the client cannot accept any
-            available types, or the result of calling the next handler in
-            the chain.
+            An HTTP 406 response if the client cannot accept any available
+            types, or ``None`` to let the request through.
 
         Raises:
-            No exceptions are raised directly; any exceptions from the
-            downstream handler are propagated unchanged.
+            No exceptions are raised directly.
         """
         best_type = self.negotiate_content_type(
             ctx, self.available_types, self.default_content_type
@@ -1296,12 +1327,18 @@ class StrictContentNegotiationMiddleware(ContentNegotiationMiddleware):
                 },
                 status_code=406,
             )
-        # Attached dynamically for downstream handlers to read. These were
-        # written with setattr(), which only had the effect of hiding them from
-        # the type checker — they are not declared on HttpContext either way.
-        ctx.negotiated_content_type = best_type  # ty: ignore[unresolved-attribute]
+        # `ctx.state`, not a plain attribute on `ctx` itself: the router
+        # builds its own fresh `HttpContext` for the handler rather than
+        # reusing this middleware's, so an attribute set here (as this used
+        # to, via `ctx.negotiated_content_type = ...`) never reached it --
+        # silently, since nothing declares that attribute to raise an
+        # AttributeError either. `ctx.state` is backed by the ASGI scope,
+        # which every `HttpContext` for this connection shares, and is the
+        # same mechanism `store_accepts_info` above already relies on to
+        # reach the handler.
+        ctx.state.negotiated_content_type = best_type
         best_language = self.negotiate_language(
             ctx, self.available_languages, self.default_language
         )
-        ctx.negotiated_language = best_language  # ty: ignore[unresolved-attribute]
-        return await call_next()
+        ctx.state.negotiated_language = best_language
+        return None

--- a/sillo/http/etag.py
+++ b/sillo/http/etag.py
@@ -2,16 +2,34 @@ from __future__ import annotations
 
 import re
 from base64 import b64encode
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from hashlib import sha1
-from typing import Any
+from typing import Any, Protocol
 
 from sillo.core.http import HttpContext
 from sillo.core.http.response import BaseResponse
-from sillo.middleware.base import BaseMiddleware
+from sillo.middleware.response_headers import ResponseHeaders
+from sillo.types import ASGIApp, Message, Receive, Scope, Send
 
 _WEAK_PREFIX = "W/"
 _ETAG_TOKEN_RE = re.compile(r'^(W/)?\s*"[^"]*"\s*$')
+
+
+class _HasHeaders(Protocol):
+    """What these functions actually need: a header-editing surface.
+
+    A :class:`BaseResponse` satisfies this, and so does a
+    :class:`~sillo.middleware.response_headers.ResponseHeaders` -- the
+    editor `ETagMiddleware` hands these functions when it has buffered a
+    response rather than built one. Neither is named here so this stays
+    correct if a third kind of header-editable object ever needs an ETag
+    stamped on it.
+    """
+
+    @property
+    def headers(self) -> Mapping[str, str]: ...
+
+    def set_header(self, key: str, value: str, override: bool = ...) -> Any: ...
 
 
 def generate_etag_from_bytes(data: bytes, weak: bool = True) -> str:
@@ -33,12 +51,12 @@ def normalize_etag(tag: str) -> str:
     return tag
 
 
-def set_response_etag(response: BaseResponse, etag: str, override: bool = True) -> None:
+def set_response_etag(response: _HasHeaders, etag: str, override: bool = True) -> None:
     response.set_header("etag", normalize_etag(etag), override=override)
 
 
 def compute_and_set_etag(
-    response: BaseResponse, body: bytes = b"", weak: bool = True, override: bool = False
+    response: _HasHeaders, body: bytes = b"", weak: bool = True, override: bool = False
 ) -> str:
     tag = generate_etag_from_bytes(body, weak=weak)
     set_response_etag(response, tag, override=override)
@@ -93,7 +111,7 @@ def etag_matches(
 
 
 def is_fresh(
-    ctx: HttpContext, response: BaseResponse, weak_compare: bool = True
+    ctx: HttpContext, response: _HasHeaders, weak_compare: bool = True
 ) -> bool:
     current = response.headers.get("etag")
     if not current:
@@ -101,8 +119,18 @@ def is_fresh(
     return etag_matches(current, parse_if_none_match(ctx), weak_compare=weak_compare)
 
 
-class ETagMiddleware(BaseMiddleware):
-    """Compute ETag headers and handle ``If-None-Match`` conditionals."""
+class ETagMiddleware:
+    """Compute ETag headers and handle ``If-None-Match`` conditionals.
+
+    An ETag has to be computed from the actual response body, and there is
+    no telling whether the downstream app is done writing that body until it
+    sends a final ``http.response.body`` message with ``more_body`` unset --
+    so unlike the header-only middleware in this package, this one has to
+    fully buffer a matching response before it can decide what to send:
+    a 304 with no body at all, or the original response with an ``ETag``
+    header added. Nothing here needs a body it isn't already going to send,
+    so nothing is held any longer than it takes to make that one decision.
+    """
 
     def __init__(
         self,
@@ -112,28 +140,78 @@ class ETagMiddleware(BaseMiddleware):
         override: bool = False,
         **kwargs: Any,
     ) -> None:
-        super().__init__(**kwargs)
+        # Bound on afterwards by `use()`: this is registered as a configured
+        # instance, `app.use(ETagMiddleware(...))`.
+        self.app: ASGIApp | None = None
         self.weak = weak
         self.methods = tuple(method.upper() for method in methods)
         self.override = override
 
-    async def dispatch(self, ctx: HttpContext, call_next: Any) -> Any:
-        """Run the chain, then attach an ETag and honour ``If-None-Match``."""
-        response = await call_next()
+    def _inner(self) -> ASGIApp:
+        """Return the inner application, refusing to serve without one."""
+        if self.app is None:
+            raise RuntimeError(
+                "ETagMiddleware was constructed without an inner application "
+                "and cannot serve requests. Register it with "
+                "app.use(ETagMiddleware(...))."
+            )
+        return self.app
 
-        if response is None or ctx.method.upper() not in self.methods:
-            return response
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Buffer a matching response, then attach an ETag or answer 304."""
+        app = self._inner()
+        if scope["type"] != "http" or scope["method"].upper() not in self.methods:
+            await app(scope, receive, send)
+            return
 
-        has_existing = bool(response.headers.get("etag"))
+        ctx = HttpContext(scope, receive)
+        start_message: Message | None = None
+        body = bytearray()
+
+        async def buffer(message: Message) -> None:
+            nonlocal start_message
+            if message["type"] == "http.response.start":
+                start_message = message
+            elif message["type"] == "http.response.body":
+                body.extend(message.get("body", b""))
+
+        await app(scope, receive, buffer)
+
+        assert start_message is not None, "downstream app sent no response.start"
+        await self.finish(ctx, start_message, bytes(body), send)
+
+    async def finish(
+        self,
+        ctx: HttpContext,
+        start_message: Message,
+        body: bytes,
+        send: Send,
+    ) -> None:
+        """Decide the ETag, then send either the buffered response or a 304."""
+        headers = ResponseHeaders(start_message)
+
+        has_existing = bool(headers.headers.get("etag"))
         if not has_existing or self.override:
-            body = _response_body(response)
-            if body is not None:
-                compute_and_set_etag(response, body, weak=self.weak, override=True)
+            compute_and_set_etag(headers, body, weak=self.weak, override=True)
 
-        if is_fresh(ctx, response, weak_compare=True):
-            return _not_modified(response)
+        if is_fresh(ctx, headers, weak_compare=True):
+            not_modified_headers = [
+                (name, value)
+                for name, value in start_message["headers"]
+                if name.decode("latin-1").lower() in _NOT_MODIFIED_HEADERS
+            ]
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 304,
+                    "headers": not_modified_headers,
+                }
+            )
+            await send({"type": "http.response.body", "body": b""})
+            return
 
-        return response
+        await send(start_message)
+        await send({"type": "http.response.body", "body": body})
 
 
 #: Headers RFC 9110 §15.4.5 requires a 304 to carry when the corresponding
@@ -148,29 +226,6 @@ _NOT_MODIFIED_HEADERS = (
     "expires",
     "vary",
 )
-
-
-def _not_modified(response: BaseResponse) -> BaseResponse:
-    """Build the 304 to send in place of *response*.
-
-    A fresh response cannot be turned into a 304 by mutating it. What arrives
-    here is a streaming response replaying the inner application's body from a
-    memory stream, and ``set_body`` writes an attribute that the streaming
-    path never reads — so the status changed to 304, ``Content-Length`` was
-    set to 0, and the original body went out behind it. A 304 carrying a body
-    is a protocol violation, and one whose declared length disagrees with what
-    it sends can desync a keep-alive connection.
-
-    Returning a new response replaces the streaming one outright, which is the
-    only way to guarantee nothing follows the headers.
-    """
-    headers = {
-        name: value
-        for name, value in response.headers.items()
-        if name.lower() in _NOT_MODIFIED_HEADERS
-    }
-
-    return BaseResponse(body=b"", status_code=304, headers=headers)
 
 
 def _response_body(response: BaseResponse) -> bytes | None:

--- a/sillo/http/lifecycle/middleware.py
+++ b/sillo/http/lifecycle/middleware.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from typing import Any
 
 from sillo.core.http import HttpContext
-from sillo.middleware.base import BaseMiddleware
+from sillo.middleware.response_headers import ResponseHeaders
+from sillo.types import ASGIApp, Message, Receive, Scope, Send
 
 from .helpers import (
     generate_request_id,
@@ -14,7 +15,7 @@ from .helpers import (
 )
 
 
-class RequestIdMiddleware(BaseMiddleware):
+class RequestIdMiddleware:
     """Middleware that manages request ID generation and propagation.
 
     Automatically assigns a unique request ID to each incoming request,
@@ -60,8 +61,9 @@ class RequestIdMiddleware(BaseMiddleware):
             include_in_response (bool, optional): When ``True``, set
                 the request ID as a header on the outgoing response.
                 Defaults to ``True``.
-            **kwargs: Additional keyword arguments forwarded to the
-                ``BaseMiddleware`` parent class.
+            **kwargs: Additional keyword arguments, accepted but ignored,
+                for compatibility with generic middleware configuration
+                patterns.
 
         Returns:
             None.
@@ -69,38 +71,55 @@ class RequestIdMiddleware(BaseMiddleware):
         Raises:
             None.
         """
-        super().__init__(**kwargs)
+        # Bound on afterwards by `use()`: this is registered as a configured
+        # instance, `app.use(RequestIdMiddleware(...))`.
+        self.app: ASGIApp | None = None
         self.header_name = header_name
         self.force_generate = force_generate
         self.store_in_request = store_in_request
         self.request_attribute_name = request_attribute_name
         self.include_in_response = include_in_response
 
-    async def dispatch(
-        self,
-        ctx: HttpContext,
-        call_next: Any,
-    ) -> Any:
-        """Assign a request ID, then guarantee it on the outgoing response.
+    def _inner(self) -> ASGIApp:
+        """Return the inner application, refusing to serve without one."""
+        if self.app is None:
+            raise RuntimeError(
+                "RequestIdMiddleware was constructed without an inner "
+                "application and cannot serve requests. Register it with "
+                "app.use(RequestIdMiddleware(...))."
+            )
+        return self.app
 
-        Determines the request ID by either forcing a fresh UUID4
-        generation or extracting/generating one from the request
-        headers. Optionally stores the ID on the request state and
-        sets it as a response header before delegating to the next
-        middleware or handler in the chain.
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Assign a request ID, then guarantee it on the outgoing response."""
+        app = self._inner()
+        if scope["type"] != "http":
+            await app(scope, receive, send)
+            return
+
+        ctx = HttpContext(scope, receive)
+        request_id = self.assign_request_id(ctx)
+
+        async def send_with_request_id(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                self.set_response_header(ResponseHeaders(message), request_id)
+            await send(message)
+
+        await app(scope, receive, send_with_request_id)
+
+    def assign_request_id(self, ctx: HttpContext) -> str:
+        """Determine this request's ID, and store it on the request state.
+
+        Forces a fresh UUID4, or extracts/generates one from the request
+        headers, per ``force_generate``. Optionally stores the ID on
+        ``ctx.state`` for downstream handlers to read.
 
         Args:
             ctx (HttpContext): The context to inspect and annotate with a
                 request ID.
-            call_next (Any): An awaitable callable representing the
-                next middleware or route handler in the pipeline.
 
         Returns:
-            Any: The return value of ``call_next()``, typically the
-                response produced by downstream handlers.
-
-        Raises:
-            None.
+            str: The request ID assigned to this request.
         """
         if self.force_generate:
             request_id = generate_request_id()
@@ -108,18 +127,25 @@ class RequestIdMiddleware(BaseMiddleware):
             request_id = get_request_id_from_header(ctx, self.header_name)
             if not request_id:
                 request_id = get_or_generate_request_id(ctx, self.header_name)
-        self.request_id = request_id
 
+        # Not kept on `self`: this middleware instance is shared across every
+        # concurrent request the application handles, and a second request's
+        # ID landing on `self` between this and `set_response_header` running
+        # would echo the wrong ID back on the first request's response.
+        # `ctx.state` below is what a caller actually wants -- one per
+        # request -- and this method's own return value carries it the rest
+        # of the way through this request's `__call__`.
         if self.store_in_request:
             store_request_id_in_request(ctx, request_id, self.request_attribute_name)
 
-        response = await call_next()
+        return request_id
 
-        if response is not None and request_id and self.include_in_response:
-            if not response.headers.get(self.header_name):
-                set_request_id_header(response, request_id, self.header_name)
-
-        return response
+    def set_response_header(self, headers: ResponseHeaders, request_id: str) -> None:
+        """Echo the request ID back on the outgoing response, if configured to."""
+        if not request_id or not self.include_in_response:
+            return
+        if not headers.headers.get(self.header_name):
+            set_request_id_header(headers, request_id, self.header_name)
 
 
 def RequestId(

--- a/sillo/middleware/__init__.py
+++ b/sillo/middleware/__init__.py
@@ -15,22 +15,20 @@ What is where:
     dispatch middleware is mounted above an ASGI application, which cannot
     return a response object on its own.
 ``gzip``, ``security``
-    Middleware that ships with the framework.
+    Middleware that ships with the framework. Every one of them -- here and
+    under ``sillo.http`` (sessions, auth, CORS, CSRF, rate limiting, security
+    headers, path normalization, request IDs, ETags, content negotiation) --
+    is plain raw ASGI: ``__init__(self, app=None, ...)`` and
+    ``async def __call__(self, scope, receive, send)``. None of them subclass
+    ``BaseMiddleware`` or import it, so there is no cycle through ``base`` to
+    worry about here any more.
 ``utils``
     :func:`~sillo.middleware.utils.use_for_route`, to scope a middleware to a
     path pattern.
 
 Only ``base`` and the shipped middleware are public API. ``define`` and
-``bridge`` are how the framework assembles a chain; import them by their module
-path rather than from here, which is also what keeps the security re-exports
-below from becoming a cycle.
-
-Those re-exports reach back into this package's own ``base`` module. Everything
-under ``sillo.security`` imports ``BaseMiddleware`` from ``sillo.middleware.base``
-directly rather than from this package, which is what keeps that from being a
-cycle — importing it from here worked only while this file happened to bind
-``BaseMiddleware`` before triggering the security import, so sorting these two
-lines was enough to raise ImportError on ``import sillo``.
+``bridge`` are how the framework assembles a chain; import them by their
+module path rather than from here.
 """
 
 from sillo.security.cors import CORSMiddleware

--- a/sillo/middleware/response_headers.py
+++ b/sillo/middleware/response_headers.py
@@ -1,0 +1,52 @@
+"""A `BaseResponse`-shaped editor over one outgoing ASGI message.
+
+Every built-in middleware that needs to add a header or a cookie to a
+response it didn't build itself -- a `Set-Cookie`, a CORS header, an
+`X-RateLimit-*` -- does it the same way: intercept the one
+`http.response.start` message as it passes through `send`, and edit its
+headers list in place before forwarding it. :class:`ResponseHeaders` is that
+edit, wrapped in the same `set_header`/`set_cookie`/`delete_cookie` surface a
+real response object offers, so that code reads exactly like it would
+against one.
+
+This is a small shared *utility*, not a shared middleware base class: each
+middleware still writes its own `__call__` and wraps `send` on its own terms
+-- what counts as "before" and "after" the downstream app, and what its
+methods are named, differs from one middleware to the next. This is only
+here so none of them re-derive cookie serialisation (`SameSite` validation,
+the `__Host-`/`__Secure-` `Secure` requirement, ...) by hand.
+"""
+
+from __future__ import annotations
+
+from sillo.core.http.response import BaseResponse
+from sillo.objects import MutableHeaders
+from sillo.types import Message
+
+
+class ResponseHeaders:
+    """Edits the headers of one `http.response.start` ASGI message.
+
+    `set_header`, `set_cookie`, `delete_cookie` and the rest are
+    `BaseResponse`'s own methods, bound here instead -- they only ever touch
+    `self.raw_headers`, so pointing that at the ASGI message's own headers
+    list is all that's needed for them to edit it directly, with none of a
+    response object's other machinery (a body, a status code, ...) along for
+    the ride.
+    """
+
+    set_header = BaseResponse.set_header
+    set_headers = BaseResponse.set_headers
+    remove_header = BaseResponse.remove_header
+    remove_headers = BaseResponse.remove_headers
+    set_cookie = BaseResponse.set_cookie
+    delete_cookie = BaseResponse.delete_cookie
+
+    def __init__(self, message: Message) -> None:
+        self.raw_headers: list[tuple[bytes, bytes]] = message["headers"]
+
+    @property
+    def headers(self) -> MutableHeaders:
+        if not hasattr(self, "_headers"):
+            self._headers = MutableHeaders(raw=self.raw_headers)
+        return self._headers

--- a/sillo/normalize/middleware.py
+++ b/sillo/normalize/middleware.py
@@ -5,8 +5,8 @@ from typing import Any
 from urllib.parse import urlunparse
 
 from sillo.core.http import HttpContext
-from sillo.middleware.base import BaseMiddleware
 from sillo.responses import redirect as _redirect
+from sillo.types import ASGIApp, Receive, Scope, Send
 
 
 class SlashAction(Enum):
@@ -33,7 +33,7 @@ class SlashAction(Enum):
     IGNORE = "ignore"
 
 
-class NormalizeMiddleware(BaseMiddleware):
+class NormalizeMiddleware:
     """
     Middleware that normalizes URL paths by handling trailing slashes and double slashes.
 
@@ -43,9 +43,9 @@ class NormalizeMiddleware(BaseMiddleware):
     HTTP redirects, and ignoring. Additionally, it can collapse consecutive slashes
     and optionally normalize path case for case-insensitive routing.
 
-    The middleware integrates with the sillo middleware system by extending
-    ``BaseMiddleware`` and overriding the ``process_request`` hook to modify
-    the request scope before downstream processing.
+    A plain raw ASGI middleware: it either mutates the request scope's path
+    in place before calling the downstream app, or answers a redirect
+    itself without calling it at all.
     """
 
     def __init__(
@@ -77,6 +77,9 @@ class NormalizeMiddleware(BaseMiddleware):
             **_ (Any): Additional keyword arguments that are accepted but ignored,
                 allowing compatibility with generic middleware configuration patterns.
         """
+        # Bound on afterwards by `use()`: this is registered as a configured
+        # instance, `app.use(NormalizeMiddleware(...))`.
+        self.app: ASGIApp | None = None
         self.slash_action = slash_action
         self.redirect_status_code = redirect_status_code
         self.auto_remove_double_slashes = auto_remove_double_slashes
@@ -179,35 +182,56 @@ class NormalizeMiddleware(BaseMiddleware):
         skip_patterns = [".", "?", "#"]
         return any(pattern in path for pattern in skip_patterns)
 
-    async def dispatch(
-        self,
-        ctx: HttpContext,
-        call_next: Any,
-    ) -> Any:
-        """
-        Processes an incoming HTTP request by applying URL normalization rules.
+    def _inner(self) -> ASGIApp:
+        """Return the inner application, refusing to serve without one."""
+        if self.app is None:
+            raise RuntimeError(
+                "NormalizeMiddleware was constructed without an inner "
+                "application and cannot serve requests. Register it with "
+                "app.use(NormalizeMiddleware(...))."
+            )
+        return self.app
 
-        This method implements the core normalization logic by inspecting the
-        request path and applying the configured slash handling strategy. It
-        first checks whether the path should be skipped, then applies double-slash
-        removal and case normalization. Based on the configured ``slash_action``,
-        it either silently modifies the path in the request scope or issues an
-        HTTP redirect response to the canonical URL form.
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Normalize the path, or redirect to its canonical form, then run the app."""
+        app = self._inner()
+        if scope["type"] != "http":
+            await app(scope, receive, send)
+            return
+
+        ctx = HttpContext(scope, receive)
+        redirect_response = self.normalize(ctx)
+        if redirect_response is not None:
+            await redirect_response(scope, receive, send)
+            return
+
+        await app(scope, receive, send)
+
+    def normalize(self, ctx: HttpContext) -> Any | None:
+        """
+        Applies URL normalization rules to one request's path.
+
+        Inspects the request path and applies the configured slash handling
+        strategy. First checks whether the path should be skipped, then
+        applies double-slash removal and case normalization. Based on the
+        configured ``slash_action``, it either silently modifies the path in
+        the request scope or returns an HTTP redirect response to the
+        canonical URL form.
 
         Args:
             ctx (HttpContext): The context whose URL path will be inspected
                 and potentially modified during normalization.
-            call_next (Any): An async callable representing the next middleware
-                or route handler in the processing chain.
 
         Returns:
-            Any: Either a redirect response if the path requires canonicalization
-            via redirect, or the result of calling the next handler in the chain.
+            Any | None: A redirect response if the path requires
+            canonicalization via redirect, or ``None`` to let the request
+            through (with the scope's path already normalized in place, if
+            configured to modify silently).
         """
         original_path = ctx.url.path
 
         if self._should_skip_processing(original_path):
-            return await call_next()
+            return None
 
         normalized_path = self._normalize_path(original_path)
 
@@ -261,7 +285,7 @@ class NormalizeMiddleware(BaseMiddleware):
                 )
                 return _redirect(redirect_url, status_code=self.redirect_status_code)
 
-        return await call_next()
+        return None
 
 
 def Normalize(

--- a/sillo/security/cors/_middleware.py
+++ b/sillo/security/cors/_middleware.py
@@ -1,15 +1,13 @@
 import re
-import typing
 from collections.abc import Callable
 from typing import Any
 
 from sillo.core.http import HttpContext
 from sillo.logging import getLogger
-
-# from typing_extensions import Annotated, Doc
-from sillo.middleware.base import BaseMiddleware
+from sillo.middleware.response_headers import ResponseHeaders
 from sillo.responses import json
 from sillo.security.cors.config import CorsConfig
+from sillo.types import ASGIApp, Message, Receive, Scope, Send
 
 logger = getLogger()
 
@@ -18,11 +16,14 @@ BASIC_HEADERS = {"Accept", "Accept-Language", "Content-Language", "Content-Type"
 SAFELISTED_HEADERS = {"accept", "accept-language", "content-language", "content-type"}
 
 
-class CORSMiddleware(BaseMiddleware):
+class CORSMiddleware:
     """Corsmiddleware"""
 
     def __init__(self, config: CorsConfig):
         """Init"""
+        # Bound on afterwards by `use()`: this is registered as a configured
+        # instance, `app.use(CORSMiddleware(config))`.
+        self.app: ASGIApp | None = None
         self.config = config
         self.allow_origins: list[str] = self.config.allow_origins or []
         self.blacklist_origins: list[str] = self.config.blacklist_origins or []
@@ -106,18 +107,51 @@ class CORSMiddleware(BaseMiddleware):
         else:
             self.allow_headers = list(SAFELISTED_HEADERS)
 
-    async def dispatch(
-        self,
-        ctx: HttpContext,
-        call_next: typing.Callable[..., typing.Awaitable[Any]],
-    ):
-        """Apply the CORS policy to one request."""
-        config = getattr(self, "config", None)
-        if not config:
-            return await call_next()
+    def _inner(self) -> ASGIApp:
+        """Return the inner application, refusing to serve without one."""
+        if self.app is None:
+            raise RuntimeError(
+                "CORSMiddleware was constructed without an inner application "
+                "and cannot serve requests. Register it with "
+                "app.use(CORSMiddleware(...))."
+            )
+        return self.app
 
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Apply the CORS policy to one connection."""
+        app = self._inner()
+        if scope["type"] != "http" or not getattr(self, "config", None):
+            await app(scope, receive, send)
+            return
+
+        ctx = HttpContext(scope, receive)
         origin = ctx.origin
 
+        rejection = await self.check_request(ctx)
+        if rejection is not None:
+            await rejection(scope, receive, send)
+            return
+
+        # Read by the server-error handler if the downstream app blows up
+        # before it can stamp its own CORS headers -- an error response is
+        # still a response the browser has to be allowed to read.
+        server_error_headers = ctx.scope.get("server_error_headers", {})
+        server_error_headers["Access-Control-Allow-Origin"] = origin
+        ctx.scope["server_error_headers"] = server_error_headers
+
+        async def send_with_cors_headers(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                self.apply_cors_headers(origin, ResponseHeaders(message))
+            await send(message)
+
+        await app(scope, receive, send_with_cors_headers)
+
+    async def check_request(self, ctx: HttpContext) -> Any | None:
+        """Reject a request missing its Origin under strict checking, or
+        answer a preflight outright. `None` means the request carries on to
+        the downstream app.
+        """
+        origin = ctx.origin
         method = ctx.scope["method"]
 
         if not origin and self.strict_origin_checking:
@@ -127,47 +161,35 @@ class CORSMiddleware(BaseMiddleware):
                 self.get_error_message("missing_origin"),
                 status_code=self.custom_error_status,
             )
+
         if (
             method.lower() == "options"
             and "access-control-request-method" in ctx.headers
         ):
             return await self.preflight_response(ctx)
-        return await self.simple_response(ctx, call_next)
 
-    async def simple_response(
-        self,
-        ctx: HttpContext,
-        call_next: typing.Callable[..., typing.Awaitable[Any]],
-    ):
-        """Run the chain, then stamp the CORS headers on what comes back."""
-        origin = ctx.origin
-        server_error_headers = ctx.scope.get("server_error_headers", {})
-        server_error_headers["Access-Control-Allow-Origin"] = origin
-        ctx.scope["server_error_headers"] = server_error_headers
-        response = await call_next()
+        return None
 
-        if response is None:
-            return None
-
+    def apply_cors_headers(self, origin: str | None, headers: ResponseHeaders) -> None:
+        """Stamp the CORS headers onto a response that ran the downstream app."""
         if origin and self.is_allowed_origin(origin):
-            response.set_header(
+            headers.set_header(
                 "Access-Control-Allow-Origin",
                 self.allow_origin_value(origin),
                 override=True,
             )
 
             if self.allow_credentials:
-                response.set_header(
+                headers.set_header(
                     "Access-Control-Allow-Credentials", "true", override=True
                 )
 
         if self.expose_headers:
-            response.set_header(
+            headers.set_header(
                 "Access-Control-Expose-Headers",
                 ", ".join(self.expose_headers),
                 override=True,
             )
-        return response
 
     def allow_origin_value(self, origin: str) -> str:
         """What to send back in ``Access-Control-Allow-Origin``.

--- a/sillo/security/csrf/_middleware.py
+++ b/sillo/security/csrf/_middleware.py
@@ -5,8 +5,10 @@ from typing import Any
 
 from sillo.core.http import HttpContext
 from sillo.helpers.signing import BadSignature, URLSafeSerializer
-from sillo.middleware.base import BaseMiddleware
+from sillo.middleware.bridge import _CachedRequest
+from sillo.middleware.response_headers import ResponseHeaders
 from sillo.responses import text
+from sillo.types import ASGIApp, Message, Receive, Scope, Send
 
 from .config import CSRFConfig
 
@@ -19,7 +21,7 @@ _FORM_CONTENT_TYPES = (
 )
 
 
-class CSRFMiddleware(BaseMiddleware):
+class CSRFMiddleware:
     """
     Middleware to protect against Cross-Site HttpContext Forgery (CSRF) attacks for sillo.
 
@@ -47,6 +49,10 @@ class CSRFMiddleware(BaseMiddleware):
                 with ``AttributeError: no attribute 'serializer'`` from inside
                 the request path rather than at startup.
         """
+        # Bound on afterwards by `use()`: this is registered as a configured
+        # instance, `app.use(CSRFMiddleware(config))`.
+        self.app: ASGIApp | None = None
+
         if config is not None:
             if not isinstance(config, CSRFConfig):
                 raise TypeError("config must be a CSRFConfig instance")
@@ -92,15 +98,50 @@ class CSRFMiddleware(BaseMiddleware):
         if self.secret and self.serializer is None:
             self.serializer = URLSafeSerializer(self.secret, "csrftoken")
 
-    async def dispatch(
-        self,
-        ctx: HttpContext,
-        call_next: typing.Callable[..., typing.Awaitable[typing.Any]],
-    ):
-        """Validate the CSRF token, then stamp it onto the reply."""
-        if not self.csrf_config or not self.use_csrf:
-            return await call_next()
+    def _inner(self) -> ASGIApp:
+        """Return the inner application, refusing to serve without one."""
+        if self.app is None:
+            raise RuntimeError(
+                "CSRFMiddleware was constructed without an inner application "
+                "and cannot serve requests. Register it with "
+                "app.use(CSRFMiddleware(...))."
+            )
+        return self.app
 
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Validate the CSRF token, then stamp it onto the reply."""
+        app = self._inner()
+        if scope["type"] != "http" or not self.csrf_config or not self.use_csrf:
+            await app(scope, receive, send)
+            return
+
+        # A submitted token can arrive in the form body, which `validate()`
+        # has to read to check it -- so the request is built with the same
+        # buffer/replay wrapper the dispatch bridge uses, and the route
+        # handler downstream still sees a body to read.
+        ctx = _CachedRequest(scope, receive)
+
+        rejection = await self.validate(ctx)
+        if rejection is not None:
+            await rejection(scope, receive, send)
+            return
+
+        scope["_sillo_body_replay"] = ctx.wrapped_receive
+
+        async def send_with_csrf_cookie(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                self.set_token_cookie(ctx, ResponseHeaders(message))
+            await send(message)
+
+        await app(scope, ctx.wrapped_receive, send_with_csrf_cookie)
+
+    async def validate(self, ctx: HttpContext) -> Any | None:
+        """Check the CSRF token, returning a 403 response to reject the request.
+
+        Always sets ``ctx.state.csrf_token`` first, so the token is available
+        (to a template, an API response, ...) whether or not this request
+        needed one checked.
+        """
         csrf_cookie = ctx.cookies.get(self.cookie_name)
 
         # Keep the token the visitor already holds. Minting a new one on every
@@ -125,20 +166,15 @@ class CSRFMiddleware(BaseMiddleware):
             if not self._csrf_tokens_match(csrf_cookie, submitted_csrf_token):
                 return text("CSRF token incorrect", status_code=403)
 
-        response = await call_next()
-        self._set_token_cookie(ctx, response)
-        return response
+        return None
 
-    def _set_token_cookie(self, ctx: HttpContext, response) -> None:
+    def set_token_cookie(self, ctx: HttpContext, headers: ResponseHeaders) -> None:
         """Put the CSRF token on the outgoing response for the client to read."""
-        if response is None:
-            return
-
         csrf_token = getattr(ctx.state, "csrf_token", None)
         if not csrf_token:
             return
 
-        response.set_cookie(
+        headers.set_cookie(
             key=self.cookie_name,
             value=csrf_token,
             path=self.cookie_path,

--- a/sillo/security/ratelimit/_middleware.py
+++ b/sillo/security/ratelimit/_middleware.py
@@ -8,12 +8,12 @@ or short-circuits with a ``429`` response carrying ``Retry-After``.
 
 from __future__ import annotations
 
-import typing
 from typing import Any
 
 from sillo.core.http import HttpContext
-from sillo.middleware.base import BaseMiddleware
+from sillo.middleware.response_headers import ResponseHeaders
 from sillo.responses import json
+from sillo.types import ASGIApp, Message, Receive, Scope, Send
 
 from .backends import RateLimitBackend, get_backend
 from .config import RateLimitConfig
@@ -24,7 +24,7 @@ _HEADER_REMAINING = "X-RateLimit-Remaining"
 _HEADER_RESET = "X-RateLimit-Reset"
 
 
-class RateLimitMiddleware(BaseMiddleware):
+class RateLimitMiddleware:
     """Enforce request rate limits per client identity."""
 
     def __init__(
@@ -33,26 +33,62 @@ class RateLimitMiddleware(BaseMiddleware):
         **kwargs: Any,
     ) -> None:
         """Init"""
+        # Bound on afterwards by `use()`: this is registered as a configured
+        # instance, `app.use(RateLimitMiddleware(config))`.
+        self.app: ASGIApp | None = None
+
         if config is not None and not isinstance(config, RateLimitConfig):
             raise TypeError("config must be a RateLimitConfig instance")
         self.config: RateLimitConfig = config or RateLimitConfig()
         self._strategy: RateLimitStrategy = get_strategy(self.config.strategy)
         self._backend: RateLimitBackend = get_backend(self.config.backend)
-        self._last_result = None  # type: ignore[var-annotated]
 
-    async def dispatch(
-        self,
-        ctx: HttpContext,
-        call_next: typing.Callable[..., typing.Awaitable[typing.Any]],
-    ):
+    def _inner(self) -> ASGIApp:
+        """Return the inner application, refusing to serve without one."""
+        if self.app is None:
+            raise RuntimeError(
+                "RateLimitMiddleware was constructed without an inner "
+                "application and cannot serve requests. Register it with "
+                "app.use(RateLimitMiddleware(...))."
+            )
+        return self.app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Count the hit, deny or continue, then stamp the limit headers."""
+        app = self._inner()
+        if scope["type"] != "http":
+            await app(scope, receive, send)
+            return
+
+        ctx = HttpContext(scope, receive)
+        result = await self.check(ctx)
+
+        if result is not None and not result.allowed:
+            response = self._deny(ctx, result)
+            await response(scope, receive, send)
+            return
+
+        async def send_with_limit_headers(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                self.set_limit_headers(ResponseHeaders(message), result)
+            await send(message)
+
+        await app(scope, receive, send_with_limit_headers)
+
+    async def check(self, ctx: HttpContext) -> Any | None:
+        """Count this request against its client's limit.
+
+        Returns the strategy's result, or `None` when there was nothing to
+        count (no key, or the backend failed open) -- the caller reads
+        `result.allowed` to decide whether to deny it.
+        """
         key = self.config._key_func(ctx)
         if key is None:
-            return await call_next()
+            return None
 
         full_key = f"{self.config.namespace}:{key}"
         try:
-            result = await self._strategy.hit(
+            return await self._strategy.hit(
                 self._backend,
                 full_key,
                 self.config.limit,
@@ -63,24 +99,15 @@ class RateLimitMiddleware(BaseMiddleware):
             if not self.config.fail_open:
                 raise
             # Backend unavailable -> allow, but don't attach limit headers.
-            return await call_next()
+            return None
 
-        self._last_result = result
-        if not result.allowed:
-            return self._deny(ctx, result)
-
-        response = await call_next()
-        self._set_limit_headers(response)
-        return response
-
-    def _set_limit_headers(self, response) -> None:
+    def set_limit_headers(self, headers: ResponseHeaders, result: Any | None) -> None:
         """Write the ``X-RateLimit-*`` headers onto the outgoing response."""
-        result = self._last_result
-        if response is None or result is None or not self.config.include_headers:
+        if result is None or not self.config.include_headers:
             return
-        response.set_header(_HEADER_LIMIT, str(result.limit), override=True)
-        response.set_header(_HEADER_REMAINING, str(result.remaining), override=True)
-        response.set_header(_HEADER_RESET, str(int(result.reset_at)), override=True)
+        headers.set_header(_HEADER_LIMIT, str(result.limit), override=True)
+        headers.set_header(_HEADER_REMAINING, str(result.remaining), override=True)
+        headers.set_header(_HEADER_RESET, str(int(result.reset_at)), override=True)
 
     def _deny(self, ctx: HttpContext, result: Any):
         """Build the 429, or hand off to a configured ``on_exceed``."""

--- a/sillo/security/shield.py
+++ b/sillo/security/shield.py
@@ -11,12 +11,12 @@ Usage::
     app.use(Shield())
 """
 
-from sillo.middleware.base import BaseMiddleware
+from sillo.middleware.response_headers import ResponseHeaders
 from sillo.responses import redirect as _redirect
-from sillo.types import HttpContext
+from sillo.types import ASGIApp, HttpContext, Message, Receive, Scope, Send
 
 
-class Shield(BaseMiddleware):
+class Shield:
     """Shield"""
 
     def __init__(
@@ -75,6 +75,10 @@ class Shield(BaseMiddleware):
         server_header: str | None = None,
     ):
         """Init"""
+        # Bound on afterwards by `use()`: this is registered as a configured
+        # instance, `app.use(Shield(...))`.
+        self.app: ASGIApp | None = None
+
         self.csp_enabled = csp_enabled
         self.csp_policy = csp_policy or {
             "default-src": ["'self'"],
@@ -152,19 +156,42 @@ class Shield(BaseMiddleware):
                 policies.append(f"{feature}=({' '.join(setting)})")
         return ", ".join(policies)
 
-    async def dispatch(self, ctx: HttpContext, call_next):
-        """Redirect to HTTPS if configured, then stamp the security headers."""
+    def _inner(self) -> ASGIApp:
+        """Return the inner application, refusing to serve without one."""
+        if self.app is None:
+            raise RuntimeError(
+                "Shield was constructed without an inner application and "
+                "cannot serve requests. Register it with app.use(Shield(...))."
+            )
+        return self.app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Redirect to HTTPS if configured, then run the app and stamp security headers."""
+        app = self._inner()
+        if scope["type"] != "http":
+            await app(scope, receive, send)
+            return
+
+        ctx = HttpContext(scope, receive)
+
         if self.ssl_redirect and ctx.url.scheme != "https":
             redirect_url = f"https://{self.ssl_host or ctx.url.hostname}{ctx.url.path}"
-            return _redirect(
+            response = _redirect(
                 redirect_url, status_code=301 if self.ssl_permanent else 302
             )
+            await response(scope, receive, send)
+            return
 
-        response = await call_next()
-        if response is None:
-            return None
+        async def send_with_security_headers(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                self.apply_security_headers(ResponseHeaders(message))
+            await send(message)
 
-        headers = dict(response.headers)
+        await app(scope, receive, send_with_security_headers)
+
+    def apply_security_headers(self, response_headers: ResponseHeaders) -> None:
+        """Stamp the configured security headers onto the outgoing response."""
+        headers = dict(response_headers.headers)
 
         if self.csp_enabled:
             header_name = (
@@ -242,5 +269,11 @@ class Shield(BaseMiddleware):
             headers.pop("Server", None)
         elif self.server_header:
             headers["Server"] = self.server_header
-        response.set_headers(headers)
-        return response
+
+        # `override_all=True`: `headers` was seeded from every header the
+        # response already had, so replacing the whole set with it is a
+        # no-op for anything Shield didn't touch and an update for what it
+        # did. The default, appending each entry, doubled every header the
+        # response already carried -- `Content-Type` and `Content-Length`
+        # included -- since they were already in `headers` before this ran.
+        response_headers.set_headers(headers, override_all=True)

--- a/sillo/session/middleware.py
+++ b/sillo/session/middleware.py
@@ -1,10 +1,10 @@
-import typing
 import warnings
 from typing import Any
 
 from sillo.core.http import HttpContext
-from sillo.middleware.base import BaseMiddleware
+from sillo.middleware.response_headers import ResponseHeaders
 from sillo.session.session_objects import Session
+from sillo.types import ASGIApp, Message, Receive, Scope, Send
 
 from .base import BaseSessionInterface
 from .config import SessionConfig, reject_unknown_settings
@@ -18,7 +18,7 @@ _COOKIE_LIMIT = 4096
 _COOKIE_ATTRIBUTE_ALLOWANCE = 128
 
 
-class SessionMiddleware(BaseMiddleware):
+class SessionMiddleware:
     """Sessionmiddleware"""
 
     def __init__(
@@ -63,7 +63,9 @@ class SessionMiddleware(BaseMiddleware):
                 "the config or be dropped, and both are surprising."
             )
 
-        super().__init__()
+        # Bound on afterwards by `use()`: this is registered as a configured
+        # instance, `app.use(SessionMiddleware(secret_key=...))`.
+        self.app: ASGIApp | None = None
 
         self.session_config = config or SessionConfig(**settings)
 
@@ -100,12 +102,35 @@ class SessionMiddleware(BaseMiddleware):
                 # filling the gap is a convenience, not a requirement.
                 pass
 
-    async def dispatch(
-        self,
-        ctx: HttpContext,
-        call_next: typing.Callable[..., typing.Awaitable[typing.Any]],
-    ):
-        """Load the session, run the chain, then persist it onto the reply."""
+    def _inner(self) -> ASGIApp:
+        """Return the inner application, refusing to serve without one."""
+        if self.app is None:
+            raise RuntimeError(
+                "SessionMiddleware was constructed without an inner "
+                "application and cannot serve requests. Register it with "
+                "app.use(SessionMiddleware(...))."
+            )
+        return self.app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Load the session, run the downstream app, then persist it onto the reply."""
+        app = self._inner()
+        if scope["type"] != "http":
+            await app(scope, receive, send)
+            return
+
+        ctx = HttpContext(scope, receive)
+        await self.load_session(ctx)
+
+        async def send_with_session_cookie(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                await self.persist_session(ctx, ResponseHeaders(message))
+            await send(message)
+
+        await app(scope, receive, send_with_session_cookie)
+
+    async def load_session(self, ctx: HttpContext) -> None:
+        """Load the session and attach it to the scope for the rest of the chain."""
         cookie_name = self.session_config.session_cookie_name or "session_id"
         session_key = ctx.cookies.get(cookie_name)
 
@@ -114,14 +139,10 @@ class SessionMiddleware(BaseMiddleware):
 
         ctx.scope["session"] = session
 
-        response = await call_next()
-        await self._persist(ctx, response)
-        return response
-
-    async def _persist(self, ctx: HttpContext, response) -> None:
+    async def persist_session(self, ctx: HttpContext, headers: ResponseHeaders) -> None:
         """Save the session and write its cookie onto the outgoing response."""
         session: Session | None = ctx.scope.get("session")
-        if session is None or response is None:
+        if session is None:
             return
 
         cookie_name = self.session_config.session_cookie_name or "session_id"
@@ -137,7 +158,7 @@ class SessionMiddleware(BaseMiddleware):
             # the browser will not accept the deletion — a `__Host-`-prefixed
             # session cookie is rejected outright when the deletion is not
             # marked Secure, and signing out leaves the cookie in place.
-            response.delete_cookie(
+            headers.delete_cookie(
                 key=cookie_name,
                 path=self.session_config.session_cookie_path or "/",
                 domain=self.session_config.session_cookie_domain,
@@ -152,7 +173,7 @@ class SessionMiddleware(BaseMiddleware):
 
             self._warn_if_oversized(cookie_name, value)
 
-            response.set_cookie(
+            headers.set_cookie(
                 key=cookie_name,
                 value=value,
                 domain=self.session_config.session_cookie_domain,

--- a/tests/test_auth/test_auth_middleware.py
+++ b/tests/test_auth/test_auth_middleware.py
@@ -10,6 +10,7 @@ This module tests the authentication middleware including:
 
 from functools import partial
 
+import anyio
 import pytest
 
 from sillo.application import SilloApp
@@ -238,3 +239,42 @@ async def test_auth_middleware_backend_exception_handling(test_client):
         res = await client.get("/protected", headers={"X-Backup-Auth": "backup_valid"})
         assert res.status_code == 200
         assert res.json()["user_id"] == "backup_user"
+
+
+def test_non_http_scope_passes_through_untouched():
+    """Websocket and lifespan connections have no request to authenticate."""
+    middleware = AuthenticationMiddleware()
+    called = {}
+
+    async def downstream(scope, receive, send):
+        called["scope"] = scope
+
+    middleware.app = downstream
+
+    async def receive():
+        return {"type": "lifespan.startup"}
+
+    async def send(message):
+        pass
+
+    anyio.run(middleware.__call__, {"type": "lifespan"}, receive, send)
+
+    assert called["scope"] == {"type": "lifespan"}
+
+
+def test_without_an_inner_app_raises():
+    middleware = AuthenticationMiddleware()
+
+    async def receive():
+        return {"type": "http.request"}
+
+    async def send(message):
+        pass
+
+    with pytest.raises(RuntimeError, match="without an inner application"):
+        anyio.run(
+            middleware.__call__,
+            {"type": "http", "path": "/x", "method": "GET", "headers": []},
+            receive,
+            send,
+        )

--- a/tests/test_cors/test_error_handling.py
+++ b/tests/test_cors/test_error_handling.py
@@ -316,9 +316,7 @@ class TestCORSErrorHandling:
         app = SilloApp()
 
         @app.get("/whitespace-method-preflight")
-        async def whitespace_method_preflight_route(
-            ctx: HttpContext
-        ):
+        async def whitespace_method_preflight_route(ctx: HttpContext):
             return json({"message": "OK"})
 
         app.use(CORSMiddleware(config=cors_config))
@@ -357,10 +355,7 @@ class TestCORSErrorHandling:
             scope = {"method": "GET"}
             headers = {}
 
-        async def call_next():
-            raise AssertionError("should not reach the route handler")
-
-        result = await middleware.dispatch(FakeContext(), call_next)
+        result = await middleware.check_request(FakeContext())
 
         assert result.status_code == 400
 
@@ -483,13 +478,21 @@ class TestCORSErrorHandling:
         middleware = CORSMiddleware(config=cors_config)
         middleware.config = None
 
-        called = {"next": False}
+        called = {"downstream": False}
 
-        async def call_next():
-            called["next"] = True
-            return "ok"
+        async def downstream_app(scope, receive, send):
+            called["downstream"] = True
 
-        result = await middleware.dispatch(None, call_next)
+        middleware.app = downstream_app
 
-        assert result == "ok"
-        assert called["next"] is True
+        scope = {"type": "http", "method": "GET", "headers": [], "path": "/"}
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message):
+            pass
+
+        await middleware(scope, receive, send)
+
+        assert called["downstream"] is True

--- a/tests/test_helpers/test_accepts.py
+++ b/tests/test_helpers/test_accepts.py
@@ -180,6 +180,40 @@ class TestAcceptsInfo:
         response = client.get("/test", headers={"Accept": "text/html, application/json"})
         assert "text/html" in response.json()["types"]
 
+    def test_parses_headers_directly_without_the_middleware_installed(self):
+        """Without AcceptsMiddleware, ctx.state.accepts_parsed was never
+        populated, so each property falls back to parsing its own header
+        directly instead of reading the cache."""
+        app = SilloApp()
+
+        @app.get("/test")
+        async def test_route(ctx: HttpContext):
+            info = AcceptsInfo(ctx)
+            return json(
+                {
+                    "accept": [i.value for i in info.accept],
+                    "language": [i.value for i in info.accept_language],
+                    "charset": [i.value for i in info.accept_charset],
+                    "encoding": [i.value for i in info.accept_encoding],
+                }
+            )
+
+        client = TestClient(app)
+        response = client.get(
+            "/test",
+            headers={
+                "Accept": "application/json",
+                "Accept-Language": "en",
+                "Accept-Charset": "utf-8",
+                "Accept-Encoding": "gzip",
+            },
+        )
+        data = response.json()
+        assert data["accept"] == ["application/json"]
+        assert data["language"] == ["en"]
+        assert data["charset"] == ["utf-8"]
+        assert data["encoding"] == ["gzip"]
+
 
 class TestContentNegotiationMiddleware:
     def test_negotiate_content_type_method(self):

--- a/tests/test_http/test_accepts_middleware.py
+++ b/tests/test_http/test_accepts_middleware.py
@@ -225,9 +225,7 @@ def test_strict_negotiation_rejects_an_unsupported_type():
     Note the endpoint must not offer the default content type, or negotiation
     falls back onto it and the request is served after all.
     """
-    client = _app_with(
-        StrictContentNegotiationMiddleware(available_types=["text/csv"])
-    )
+    client = _app_with(StrictContentNegotiationMiddleware(available_types=["text/csv"]))
     resp = client.get("/x", headers={"Accept": "application/xml"})
     assert resp.status_code == 406
     assert "text/csv" in resp.text
@@ -257,6 +255,39 @@ def test_strict_negotiation_with_no_accept_header():
         StrictContentNegotiationMiddleware(available_types=["application/json"])
     )
     assert client.get("/x").status_code in (200, 406)
+
+
+def test_negotiated_values_reach_the_handler():
+    """The route handler gets its own, separately-built HttpContext.
+
+    The negotiated values used to be set as a plain attribute on the
+    middleware's own context object, which the handler's context never saw
+    -- so this reads them the way a handler actually would, off ctx.state,
+    not off the object the middleware happened to negotiate against.
+    """
+    app = SilloApp()
+
+    @app.get("/x")
+    async def x(ctx):
+        return json(
+            {
+                "type": ctx.state.negotiated_content_type,
+                "lang": ctx.state.negotiated_language,
+            }
+        )
+
+    app.use(
+        StrictContentNegotiationMiddleware(
+            available_types=["application/json"], available_languages=["en"]
+        )
+    )
+    client = TestClient(app)
+
+    response = client.get(
+        "/x", headers={"Accept": "application/json", "Accept-Language": "en"}
+    )
+
+    assert response.json() == {"type": "application/json", "lang": "en"}
 
 
 # ── the Accepts factory ──────────────────────────────────────────────────

--- a/tests/test_http/test_accepts_middleware.py
+++ b/tests/test_http/test_accepts_middleware.py
@@ -106,6 +106,37 @@ def test_best_match_through_a_request(client):
     assert data["language"] == "fr"
 
 
+def test_best_match_falls_back_when_nothing_matches(client):
+    """Neither the type nor the language is one the server offers, so both
+    fall back to the first option -- there is always something to answer with."""
+    resp = client.get(
+        "/best",
+        headers={"Accept": "text/csv", "Accept-Language": "de"},
+    )
+    data = resp.json()
+    assert data["type"] == "application/json"
+    assert data["language"] == "en"
+
+
+def test_best_match_matches_a_language_region_prefix(client):
+    resp = client.get("/best", headers={"Accept-Language": "en-GB"})
+    assert resp.json()["language"] == "en"
+
+
+def test_best_match_matches_a_server_side_region_variant():
+    """A server offering `en-US` satisfies a client that only asked for `en`."""
+    app = SilloApp()
+    app.use(AcceptsMiddleware())
+
+    @app.get("/best-region")
+    async def best_region(ctx):
+        return json({"language": get_best_accepted_language(ctx, ["en-US", "fr"])})
+
+    client = TestClient(app)
+    resp = client.get("/best-region", headers={"Accept-Language": "en-GB"})
+    assert resp.json()["language"] == "en-US"
+
+
 def test_the_accepts_wrapper_is_available(client):
     assert client.get("/wrapper").json()["has_accepts"] is True
 
@@ -196,6 +227,105 @@ def test_accepts_middleware_without_an_accept_header():
     assert client.get("/x").status_code == 200
 
 
+def test_negotiates_content_type_when_the_response_has_none():
+    """`apply_headers` only fills in Content-Type when the response left it blank."""
+    from sillo.core.http.response import BaseResponse
+
+    app = SilloApp()
+
+    @app.get("/x")
+    async def x(ctx):
+        return BaseResponse(body=b"data", content_type=None)
+
+    app.use(AcceptsMiddleware(default_content_type="text/csv"))
+    client = TestClient(app)
+
+    response = client.get("/x", headers={"Accept": "text/csv"})
+    assert response.headers["content-type"] == "text/csv"
+
+
+def test_falls_back_to_the_default_content_type_without_an_accept_header():
+    """No `Accept` header at all -- not even `*/*`, which a real HTTP client
+    always sends, and which would take the *other* branch (negotiating `*/*`
+    against the default, landing on the same value through a different
+    path). Driven at the ASGI level directly so the request can omit it."""
+    import anyio
+
+    from sillo.core.http.response import BaseResponse
+
+    app = SilloApp()
+
+    @app.get("/x")
+    async def x(ctx):
+        return BaseResponse(body=b"data", content_type=None)
+
+    app.use(AcceptsMiddleware(default_content_type="application/xml"))
+
+    sent: list[dict] = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/x",
+        "headers": [],
+        "query_string": b"",
+    }
+
+    anyio.run(app, scope, receive, send)
+
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    headers = {k.decode(): v.decode() for k, v in start["headers"]}
+    assert headers["content-type"] == "application/xml"
+
+
+def test_non_http_scope_passes_through_untouched():
+    middleware = AcceptsMiddleware()
+    called = {}
+
+    async def downstream(scope, receive, send):
+        called["scope"] = scope
+
+    middleware.app = downstream
+
+    async def receive():
+        return {"type": "lifespan.startup"}
+
+    async def send(message):
+        pass
+
+    import anyio
+
+    anyio.run(middleware.__call__, {"type": "lifespan"}, receive, send)
+
+    assert called["scope"] == {"type": "lifespan"}
+
+
+def test_without_an_inner_app_raises():
+    import anyio
+
+    middleware = AcceptsMiddleware()
+
+    async def receive():
+        return {"type": "http.request"}
+
+    async def send(message):
+        pass
+
+    with pytest.raises(RuntimeError, match="without an inner application"):
+        anyio.run(
+            middleware.__call__,
+            {"type": "http", "path": "/x", "method": "GET", "headers": []},
+            receive,
+            send,
+        )
+
+
 # ── ContentNegotiationMiddleware ─────────────────────────────────────────
 
 
@@ -255,6 +385,28 @@ def test_strict_negotiation_with_no_accept_header():
         StrictContentNegotiationMiddleware(available_types=["application/json"])
     )
     assert client.get("/x").status_code in (200, 406)
+
+
+def test_strict_negotiation_non_http_scope_passes_through_untouched():
+    middleware = StrictContentNegotiationMiddleware(available_types=["application/json"])
+    called = {}
+
+    async def downstream(scope, receive, send):
+        called["scope"] = scope
+
+    middleware.app = downstream
+
+    async def receive():
+        return {"type": "lifespan.startup"}
+
+    async def send(message):
+        pass
+
+    import anyio
+
+    anyio.run(middleware.__call__, {"type": "lifespan"}, receive, send)
+
+    assert called["scope"] == {"type": "lifespan"}
 
 
 def test_negotiated_values_reach_the_handler():

--- a/tests/test_http/test_accepts_negotiation.py
+++ b/tests/test_http/test_accepts_negotiation.py
@@ -58,6 +58,13 @@ def test_parse_malformed_quality_is_treated_as_unacceptable():
     assert items[0].quality == 0.0
 
 
+def test_parse_a_parameter_without_an_equals_sign_folds_into_the_value():
+    """A bare token after `;` (no `key=value`) isn't a real parameter, so it
+    stays part of the media range rather than being dropped."""
+    items = parse_accept_header("text/html;boundary")
+    assert items[0].value == "text/html;boundary"
+
+
 def test_parse_language():
     items = parse_accept_language("en-GB, en;q=0.8, fr;q=0.5")
     assert [i.value for i in items] == ["en-GB", "en", "fr"]
@@ -134,12 +141,46 @@ def test_negotiate_language_falls_back_to_the_first_available():
     assert negotiate_language("de", ["en", "fr"]) == "en"
 
 
+def test_negotiate_language_with_an_empty_header_takes_the_first_option():
+    assert negotiate_language("", ["en", "fr"]) == "en"
+
+
+def test_negotiate_language_with_no_available_languages_is_none():
+    assert negotiate_language("en", []) is None
+
+
+def test_negotiate_language_skips_zero_quality():
+    assert negotiate_language("en;q=0", ["en"]) == "en"  # falls through to the default
+
+
+def test_negotiate_language_matches_a_region_prefix():
+    """`en-GB` satisfies a server that only offers plain `en`."""
+    assert negotiate_language("en-GB", ["en"]) == "en"
+
+
+def test_negotiate_language_matches_a_region_from_the_server_side():
+    """A server offering `en-US` satisfies a client that only asked for `en`."""
+    assert negotiate_language("en-AU", ["en-US"]) == "en-US"
+
+
 def test_negotiate_charset():
     assert negotiate_charset("utf-8, iso-8859-1;q=0.5", ["utf-8"]) == "utf-8"
 
 
 def test_negotiate_charset_falls_back_to_the_first_available():
     assert negotiate_charset("iso-8859-1", ["utf-8"]) == "utf-8"
+
+
+def test_negotiate_charset_skips_zero_quality():
+    assert negotiate_charset("utf-8;q=0", ["utf-8"]) == "utf-8"  # falls to the default
+
+
+def test_negotiate_charset_with_an_empty_header_takes_the_first_option():
+    assert negotiate_charset("", ["utf-8", "iso-8859-1"]) == "utf-8"
+
+
+def test_negotiate_charset_honours_the_wildcard():
+    assert negotiate_charset("*", ["utf-8", "iso-8859-1"]) == "utf-8"
 
 
 def test_negotiate_encoding_returns_every_acceptable_option():
@@ -149,6 +190,23 @@ def test_negotiate_encoding_returns_every_acceptable_option():
 
 def test_negotiate_encoding_no_match():
     assert negotiate_encoding("compress", ["gzip"]) == []
+
+
+def test_negotiate_encoding_with_an_empty_header_is_empty():
+    assert negotiate_encoding("", ["gzip"]) == []
+
+
+def test_negotiate_encoding_with_no_available_encodings_is_empty():
+    assert negotiate_encoding("gzip", []) == []
+
+
+def test_negotiate_encoding_skips_zero_quality():
+    assert negotiate_encoding("gzip;q=0, br", ["gzip", "br"]) == ["br"]
+
+
+def test_negotiate_encoding_star_accepts_everything_but_identity():
+    result = negotiate_encoding("*", ["gzip", "br", "identity"])
+    assert set(result) == {"gzip", "br"}
 
 
 # ── helpers ──────────────────────────────────────────────────────────────
@@ -162,6 +220,19 @@ def test_get_best_match():
 
 def test_get_best_match_without_options():
     assert get_best_match("text/html", []) is None
+
+
+def test_get_best_match_skips_zero_quality():
+    assert (
+        get_best_match("text/html;q=0, application/json", ["text/html", "application/json"])
+        == "application/json"
+    )
+
+
+def test_get_best_match_falls_back_when_nothing_matched():
+    """Every candidate was either skipped or a non-match, so the loop ends
+    without returning and the first option is used as the default."""
+    assert get_best_match("text/html;q=0", ["application/json"]) == "application/json"
 
 
 def test_create_vary_header_from_nothing():

--- a/tests/test_lifecycle/test_request_id.py
+++ b/tests/test_lifecycle/test_request_id.py
@@ -79,6 +79,33 @@ class TestRequestIdMiddleware:
         response = client.get("/test")
         assert "X-Request-ID" not in response.headers
 
+    def test_assigning_one_request_id_does_not_touch_the_shared_instance(self):
+        """One middleware instance serves every concurrent request.
+
+        `assign_request_id` used to write its result onto `self`, which a
+        second request assigning its own ID -- interleaved with the first,
+        since both share this same instance -- would overwrite before the
+        first request's response echoed it back. Nothing request-specific
+        should land on the instance at all; each request's ID lives only in
+        its own `ctx.state` and this method's return value.
+        """
+        middleware = RequestIdMiddleware()
+
+        class FakeState:
+            def update(self, values: dict) -> None:
+                self.__dict__.update(values)
+
+        class FakeContext:
+            def __init__(self):
+                self.headers: dict = {}
+                self.state = FakeState()
+
+        first_id = middleware.assign_request_id(FakeContext())
+        second_id = middleware.assign_request_id(FakeContext())
+
+        assert first_id != second_id
+        assert not hasattr(middleware, "request_id")
+
 
 class TestRequestIdHelpers:
     def test_generate_request_id_is_valid_uuid(self):

--- a/tests/test_lifecycle/test_request_id.py
+++ b/tests/test_lifecycle/test_request_id.py
@@ -1,7 +1,11 @@
+import anyio
+import pytest
+
 from sillo import SilloApp
 from sillo import json
 from sillo.core.http import HttpContext
 from sillo.http.lifecycle import (
+    RequestId,
     RequestIdMiddleware,
     generate_request_id,
     validate_request_id,
@@ -105,6 +109,56 @@ class TestRequestIdMiddleware:
 
         assert first_id != second_id
         assert not hasattr(middleware, "request_id")
+
+    def test_request_id_factory_builds_a_working_middleware(self):
+        app = SilloApp()
+        app.use(
+            RequestId(header_name="X-Custom-ID", force_generate=True)
+        )
+
+        @app.get("/test")
+        async def test_route(ctx: HttpContext):
+            return json({"ok": True})
+
+        client = TestClient(app)
+        response = client.get("/test")
+        assert validate_request_id(response.headers["X-Custom-ID"])
+
+    def test_non_http_scope_passes_through_untouched(self):
+        middleware = RequestIdMiddleware()
+        called = {}
+
+        async def downstream(scope, receive, send):
+            called["scope"] = scope
+
+        middleware.app = downstream
+
+        async def receive():
+            return {"type": "lifespan.startup"}
+
+        async def send(message):
+            pass
+
+        anyio.run(middleware.__call__, {"type": "lifespan"}, receive, send)
+
+        assert called["scope"] == {"type": "lifespan"}
+
+    def test_without_an_inner_app_raises(self):
+        middleware = RequestIdMiddleware()
+
+        async def receive():
+            return {"type": "http.request"}
+
+        async def send(message):
+            pass
+
+        with pytest.raises(RuntimeError, match="without an inner application"):
+            anyio.run(
+                middleware.__call__,
+                {"type": "http", "path": "/x", "method": "GET", "headers": []},
+                receive,
+                send,
+            )
 
 
 class TestRequestIdHelpers:

--- a/tests/test_middleware/test_raw_asgi_layers.py
+++ b/tests/test_middleware/test_raw_asgi_layers.py
@@ -21,6 +21,11 @@ import pytest
 
 from sillo import SilloApp
 from sillo import json
+from sillo.application import (
+    _is_raw_asgi_middleware,
+    _rebinding_factory,
+    _runtime_call_signature,
+)
 from sillo.middleware.bridge import ASGIRequestResponseBridge
 from sillo.core.error.handler import ServerErrorMiddleware
 from sillo.core.http import HttpContext
@@ -55,7 +60,9 @@ class Tagging(BaseMiddleware):
 class StampHeader:
     """A raw ASGI middleware in the ordinary shape: factory taking the next app."""
 
-    def __init__(self, app: ASGIApp, header: str = "x-stamp", value: str = "on") -> None:
+    def __init__(
+        self, app: ASGIApp, header: str = "x-stamp", value: str = "on"
+    ) -> None:
         self.app = app
         self.header = header.encode()
         self.value = value.encode()
@@ -476,3 +483,130 @@ class TestAMiddlewareBuiltWithoutAnInnerApp:
         assert "boom" in ServerErrorMiddleware(debug=True).generate_html(
             RuntimeError("boom"), None
         )
+
+
+class TestRawIsInferredFromTheSignature:
+    """`raw=` need not be passed at all: `use()` reads it off `__call__`."""
+
+    def test_a_bare_asgi_factory_is_detected_as_raw(
+        self, test_client_factory: Callable[[SilloApp], TestClient]
+    ):
+        app = _app()
+        app.use(StampHeader)  # no raw=True
+
+        with test_client_factory(app) as client:
+            assert client.get("/ping").headers["x-stamp"] == "on"
+
+    def test_a_dispatch_instance_is_still_detected_as_dispatch(
+        self, test_client_factory: Callable[[SilloApp], TestClient]
+    ):
+        app = _app()
+        app.use(Tagging("inferred"))  # no raw=False
+
+        with test_client_factory(app) as client:
+            assert client.get("/ping").json()["tags"] == ["inferred"]
+
+    def test_differently_named_parameters_are_still_read_as_asgi(
+        self, test_client_factory: Callable[[SilloApp], TestClient]
+    ):
+        class Renamed:
+            def __init__(self, app: ASGIApp) -> None:
+                self.app = app
+
+            async def __call__(self, s: Scope, r: Receive, w: Send) -> None:
+                await self.app(s, r, w)
+
+        app = _app()
+        app.use(Renamed)
+
+        with test_client_factory(app) as client:
+            assert client.get("/ping").status_code == 200
+
+    def test_an_already_constructed_raw_instance_is_bound_and_used(
+        self, test_client_factory: Callable[[SilloApp], TestClient]
+    ):
+        # The registration style every built-in (SessionMiddleware and
+        # friends) actually uses: a configured instance, not a bare class.
+        stamp = StampHeader.__new__(StampHeader)
+        stamp.header = b"x-stamp"
+        stamp.value = b"on"
+
+        app = _app()
+        app.use(stamp)
+
+        assert stamp.app is not None  # bound by use(), not by StampHeader.__init__
+
+        with test_client_factory(app) as client:
+            assert client.get("/ping").headers["x-stamp"] == "on"
+
+    def test_a_generic_signature_falls_back_to_dispatch(self):
+        # (*args, **kwargs) carries no structural signal either way, so the
+        # pre-existing dispatch default applies -- and dispatch rejects
+        # what look like factory arguments, same as an explicit raw=False.
+        class Generic:
+            async def __call__(self, *args, **kwargs):
+                pass
+
+        app = _app()
+
+        with pytest.raises(TypeError, match="raw ASGI middleware"):
+            app.use(Generic(), "extra")
+
+    def test_raw_can_still_be_stated_explicitly(
+        self, test_client_factory: Callable[[SilloApp], TestClient]
+    ):
+        app = _app()
+        app.use(StampHeader, raw=True)
+
+        with test_client_factory(app) as client:
+            assert client.get("/ping").headers["x-stamp"] == "on"
+
+
+class TestTheInferenceHelpersDirectly:
+    """Unit-level coverage for the edge cases a full request never reaches."""
+
+    def test_a_class_with_no_call_at_all_is_not_raw(self):
+        # `getattr(cls, "__call__")` falls back to the metaclass's own
+        # `__call__` (what makes `cls(...)` construct an instance in the
+        # first place), so this reads as `(*args, **kwargs)` rather than
+        # "no signature at all" -- which still isn't mistaken for either
+        # shape, since a generic signature carries no structural signal.
+        class NotCallable:
+            pass
+
+        assert _is_raw_asgi_middleware(NotCallable) is False
+
+    def test_a_non_callable_instance_is_not_raw(self):
+        assert _is_raw_asgi_middleware(object()) is False
+        assert _runtime_call_signature(object()) is None
+
+    def test_a_call_whose_signature_cannot_be_read_is_not_raw(self):
+        # Built-in callables like `dict().__call__`... most C callables raise
+        # ValueError from inspect.signature; `str.join` is a reliable one.
+        assert _runtime_call_signature(str.join) is not None  # sanity: this one *can*
+        assert (
+            _is_raw_asgi_middleware(len) is False
+        )  # len() -- signature-less in CPython
+
+    def test_four_required_positional_parameters_is_neither_shape(self):
+        class FourParams:
+            async def __call__(self, a, b, c, d):
+                pass
+
+        assert _is_raw_asgi_middleware(FourParams) is False
+
+    def test_rebinding_factory_sets_app_and_returns_the_same_instance(self):
+        class Recorder:
+            app = None
+
+            async def __call__(self, scope, receive, send):
+                pass
+
+        instance = Recorder()
+        factory = _rebinding_factory(instance)
+
+        sentinel = object()
+        result = factory(sentinel)
+
+        assert result is instance
+        assert instance.app is sentinel

--- a/tests/test_middleware/test_security_middleware.py
+++ b/tests/test_middleware/test_security_middleware.py
@@ -177,9 +177,7 @@ def test_frame_options_sameorigin():
 
 def test_frame_options_allow_from():
     app = create_app()
-    app.use(
-        Shield(frame_options_allow_from="https://example.com")
-    )
+    app.use(Shield(frame_options_allow_from="https://example.com"))
 
     with TestClient(app) as client:
         resp = client.get("/test")
@@ -207,9 +205,7 @@ def test_content_type_options_disabled():
 
 def test_referrer_policy():
     app = create_app()
-    app.use(
-        Shield(referrer_policy="strict-origin-when-cross-origin")
-    )
+    app.use(Shield(referrer_policy="strict-origin-when-cross-origin"))
 
     with TestClient(app) as client:
         resp = client.get("/test")
@@ -311,9 +307,7 @@ def test_server_header_hidden():
 
 def test_server_header_custom():
     app = create_app()
-    app.use(
-        Shield(server_header="Custom-Server/1.0", hide_server=False)
-    )
+    app.use(Shield(server_header="Custom-Server/1.0", hide_server=False))
 
     with TestClient(app) as client:
         resp = client.get("/test")
@@ -332,11 +326,7 @@ def test_trusted_types_enabled():
 
 def test_trusted_types_with_policies():
     app = create_app()
-    app.use(
-        Shield(
-            trusted_types=True, trusted_types_policies=["policy1", "policy2"]
-        )
-    )
+    app.use(Shield(trusted_types=True, trusted_types_policies=["policy1", "policy2"]))
 
     with TestClient(app) as client:
         resp = client.get("/test")
@@ -364,3 +354,26 @@ def test_all_security_headers_present():
         ]
         for header in expected_headers:
             assert header in resp.headers, f"Missing: {header}"
+
+
+def test_headers_shield_does_not_touch_are_not_duplicated():
+    """`Content-Type` and `Content-Length` must appear exactly once.
+
+    Shield used to compute its additions into a dict seeded from every
+    header the response already had, then hand the whole thing to
+    `set_headers()` without `override_all` -- which appends rather than
+    replaces, so anything already present (headers Shield never meant to
+    touch, like these two) came out twice.
+    """
+    app = SilloApp()
+    app.use(Shield())
+
+    @app.get("/test")
+    async def test_route(ctx: HttpContext):
+        return json({"message": "OK"})
+
+    with TestClient(app) as client:
+        resp = client.get("/test")
+        names = [name for name, _ in resp.headers.multi_items()]
+        for header in ("content-type", "content-length"):
+            assert names.count(header) == 1, f"{header} appeared {names.count(header)}x"

--- a/tests/test_middleware/test_security_middleware.py
+++ b/tests/test_middleware/test_security_middleware.py
@@ -2,6 +2,9 @@
 Tests for Shield (security headers middleware)
 """
 
+import anyio
+import pytest
+
 from sillo import SilloApp
 from sillo import json
 from sillo.core.http import HttpContext
@@ -296,6 +299,74 @@ def test_permissions_policy():
         assert "geolocation=self" in pp
 
 
+def test_permissions_policy_with_a_list_value():
+    """A feature can also be scoped to a list of allowed origins."""
+    app = create_app()
+    app.use(Shield(permissions_policy={"geolocation": ["self", "https://example.com"]}))
+
+    with TestClient(app) as client:
+        resp = client.get("/test")
+        assert "geolocation=(self https://example.com)" in resp.headers["Permissions-Policy"]
+
+
+def test_csp_source_given_as_a_bare_string():
+    """A directive's sources may be a single string, not just a list."""
+    app = create_app()
+    app.use(Shield(csp_policy={"default-src": "'self'"}))
+
+    with TestClient(app) as client:
+        resp = client.get("/test")
+        assert "default-src 'self'" in resp.headers["Content-Security-Policy"]
+
+
+def test_expect_ct_enforce_and_report_uri():
+    app = create_app()
+    app.use(
+        Shield(
+            expect_ct=True,
+            expect_ct_enforce=True,
+            expect_ct_report_uri="https://example.com/report",
+        )
+    )
+
+    with TestClient(app) as client:
+        resp = client.get("/test")
+        expect_ct = resp.headers["Expect-CT"]
+        assert "enforce" in expect_ct
+        assert 'report-uri="https://example.com/report"' in expect_ct
+
+
+def test_report_to_header():
+    app = create_app()
+    report_to = {"group": "default", "max_age": 10886400, "endpoints": [{"url": "https://example.com/reports"}]}
+    app.use(Shield(report_to=report_to))
+
+    with TestClient(app) as client:
+        resp = client.get("/test")
+        assert "endpoints" in resp.headers["Report-To"]
+
+
+def test_nel_header():
+    app = create_app()
+    app.use(Shield(nel={"report_to": "default", "max_age": 2592000}))
+
+    with TestClient(app) as client:
+        resp = client.get("/test")
+        assert "default" in resp.headers["NEL"]
+
+
+def test_trusted_types_without_an_existing_csp_header():
+    """When CSP itself is off, trusted-types starts a fresh header rather
+    than appending to one that was never built."""
+    app = create_app()
+    app.http_middleware = []
+    app.use(Shield(csp_enabled=False, trusted_types=True))
+
+    with TestClient(app) as client:
+        resp = client.get("/test")
+        assert resp.headers["Content-Security-Policy"] == "require-trusted-types-for 'script'"
+
+
 def test_server_header_hidden():
     app = create_app()
     app.use(Shield(hide_server=True))
@@ -377,3 +448,84 @@ def test_headers_shield_does_not_touch_are_not_duplicated():
         names = [name for name, _ in resp.headers.multi_items()]
         for header in ("content-type", "content-length"):
             assert names.count(header) == 1, f"{header} appeared {names.count(header)}x"
+
+
+def test_ssl_redirect_answers_before_the_downstream_app_runs():
+    app = SilloApp()
+    app.use(Shield(ssl_redirect=True))
+    called = {"handler": False}
+
+    @app.get("/test")
+    async def test_route(ctx: HttpContext):
+        called["handler"] = True
+        return json({"message": "OK"})
+
+    with TestClient(app) as client:
+        resp = client.get("/test", follow_redirects=False)
+        assert resp.status_code == 301
+        assert resp.headers["location"].startswith("https://")
+        assert called["handler"] is False
+
+
+def test_ssl_redirect_is_302_when_not_permanent():
+    app = SilloApp()
+    app.use(Shield(ssl_redirect=True, ssl_permanent=False))
+
+    @app.get("/test")
+    async def test_route(ctx: HttpContext):
+        return json({"message": "OK"})
+
+    with TestClient(app) as client:
+        resp = client.get("/test", follow_redirects=False)
+        assert resp.status_code == 302
+
+
+def test_ssl_redirect_uses_ssl_host_override():
+    app = SilloApp()
+    app.use(Shield(ssl_redirect=True, ssl_host="secure.example.com"))
+
+    @app.get("/test")
+    async def test_route(ctx: HttpContext):
+        return json({"message": "OK"})
+
+    with TestClient(app) as client:
+        resp = client.get("/test", follow_redirects=False)
+        assert resp.headers["location"].startswith("https://secure.example.com")
+
+
+def test_non_http_scope_passes_through_untouched():
+    middleware = Shield()
+    called = {}
+
+    async def downstream(scope, receive, send):
+        called["scope"] = scope
+
+    middleware.app = downstream
+
+    async def receive():
+        return {"type": "lifespan.startup"}
+
+    async def send(message):
+        pass
+
+    anyio.run(middleware.__call__, {"type": "lifespan"}, receive, send)
+
+    assert called["scope"] == {"type": "lifespan"}
+
+
+def test_without_an_inner_app_raises():
+    middleware = Shield()
+
+    async def receive():
+        return {"type": "http.request"}
+
+    async def send(message):
+        pass
+
+    with pytest.raises(RuntimeError, match="without an inner application"):
+        anyio.run(
+            middleware.__call__,
+            {"type": "http", "path": "/x", "method": "GET", "headers": []},
+            receive,
+            send,
+        )

--- a/tests/test_normalize/test_middleware.py
+++ b/tests/test_normalize/test_middleware.py
@@ -1,3 +1,6 @@
+import anyio
+import pytest
+
 from sillo import SilloApp
 from sillo import json, text
 from sillo.core.http import HttpContext
@@ -73,3 +76,86 @@ class TestNormalizeMiddleware:
         client = TestClient(app)
         response = client.get("/API/TEST")
         assert response.status_code == 200
+
+    def test_double_slashes_are_actually_collapsed(self):
+        """`auto_remove_double_slashes` has to run into an actual `//` to bite."""
+        app = SilloApp()
+        app.use(NormalizeMiddleware(slash_action=SlashAction.IGNORE))
+
+        @app.get("/api/test")
+        async def test_route(ctx: HttpContext):
+            return json({"path": ctx.url.path})
+
+        client = TestClient(app)
+        response = client.get("/api//test")
+        assert response.status_code == 200
+        assert response.json()["path"] == "/api/test"
+
+    def test_redirect_remove_actually_redirects(self):
+        app = SilloApp()
+        app.use(NormalizeMiddleware(slash_action=SlashAction.REDIRECT_REMOVE))
+
+        @app.get("/test")
+        async def test_route(ctx: HttpContext):
+            return json({"path": ctx.url.path})
+
+        client = TestClient(app)
+        response = client.get("/test/", follow_redirects=False)
+        assert response.status_code == 301
+        assert response.headers["location"].endswith("/test")
+
+    def test_redirect_add_actually_redirects(self):
+        app = SilloApp()
+        app.use(
+            NormalizeMiddleware(
+                slash_action=SlashAction.REDIRECT_ADD, redirect_status_code=308
+            )
+        )
+
+        @app.get("/test/")
+        async def test_route(ctx: HttpContext):
+            return json({"path": ctx.url.path})
+
+        client = TestClient(app)
+        response = client.get("/test", follow_redirects=False)
+        assert response.status_code == 308
+        assert response.headers["location"].endswith("/test/")
+
+    def test_non_http_scope_passes_through_untouched(self):
+        """Lifespan and websocket scopes are forwarded, never normalized."""
+        middleware = NormalizeMiddleware(slash_action=SlashAction.REDIRECT_REMOVE)
+        called = {}
+
+        async def downstream(scope, receive, send):
+            called["scope"] = scope
+
+        middleware.app = downstream
+
+        async def receive():
+            return {"type": "lifespan.startup"}
+
+        async def send(message):
+            pass
+
+        anyio.run(
+            middleware.__call__, {"type": "lifespan"}, receive, send
+        )
+
+        assert called["scope"] == {"type": "lifespan"}
+
+    def test_without_an_inner_app_raises(self):
+        middleware = NormalizeMiddleware()
+
+        async def receive():
+            return {"type": "http.request"}
+
+        async def send(message):
+            pass
+
+        with pytest.raises(RuntimeError, match="without an inner application"):
+            anyio.run(
+                middleware.__call__,
+                {"type": "http", "path": "/x", "method": "GET", "headers": []},
+                receive,
+                send,
+            )

--- a/tests/test_security/test_csrf_predicates.py
+++ b/tests/test_security/test_csrf_predicates.py
@@ -10,6 +10,7 @@ broken".
 
 from __future__ import annotations
 
+import anyio
 import pytest
 
 from sillo.security.csrf import CSRFConfig
@@ -208,3 +209,128 @@ class TestTokens:
 
         assert twin != token
         assert instance._csrf_tokens_match(token, twin) is False
+
+    def test_a_signed_non_string_payload_does_not_match(self):
+        """`_generate_csrf_token` only ever signs a string, but the compare
+        itself must not assume that -- a signed non-string payload (however
+        it got signed) has to be rejected, not raise trying to compare it."""
+        instance = middleware()
+        not_a_string = instance.serializer.dumps(12345)
+        token = instance._generate_csrf_token()
+
+        assert instance._csrf_tokens_match(token, not_a_string) is False
+        assert instance._csrf_tokens_match(not_a_string, not_a_string) is False
+
+
+class TestRequiresValidation:
+    def test_an_unrequired_url_needs_no_token(self):
+        """The wrapper's own short-circuit, not `_url_is_required` in isolation."""
+        instance = middleware(required_urls=[r"/admin/.*"])
+
+        class FakeUrl:
+            path = "/public"
+
+        class FakeCtx:
+            url = FakeUrl()
+
+        assert instance._requires_validation(FakeCtx()) is False
+
+
+class TestSubmittedToken:
+    async def test_an_unparseable_form_body_carries_no_token(self):
+        """A body that claims to be form-encoded but cannot be parsed as one
+        must not blow up the middleware -- that is a 403 below, not a 500."""
+        instance = middleware()
+
+        class FakeCtx:
+            headers = {"content-type": "multipart/form-data"}
+
+            @property
+            async def form(self):
+                raise ValueError("not actually a valid multipart body")
+
+        assert await instance._submitted_token(FakeCtx()) is None
+
+
+class TestSetTokenCookie:
+    def test_is_a_noop_without_a_token_on_state(self):
+        from sillo.middleware.response_headers import ResponseHeaders
+
+        instance = middleware()
+
+        class FakeState:
+            pass
+
+        class FakeCtx:
+            state = FakeState()
+
+        message = {"type": "http.response.start", "status": 200, "headers": []}
+        instance.set_token_cookie(FakeCtx(), ResponseHeaders(message))
+
+        assert message["headers"] == []
+
+
+class TestCallEnvelope:
+    def test_non_http_scope_passes_through_untouched(self):
+        instance = middleware()
+        called = {}
+
+        async def downstream(scope, receive, send):
+            called["scope"] = scope
+
+        instance.app = downstream
+
+        async def receive():
+            return {"type": "lifespan.startup"}
+
+        async def send(message):
+            pass
+
+        anyio.run(instance.__call__, {"type": "lifespan"}, receive, send)
+
+        assert called["scope"] == {"type": "lifespan"}
+
+    def test_a_disabled_middleware_passes_every_request_through(self):
+        """`csrf_config=None` (the default) means "not enabled" -- checked
+        before validate() ever runs, not just answered false by it."""
+        instance = CSRFMiddleware()
+        called = {}
+
+        async def downstream(scope, receive, send):
+            called["ran"] = True
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b""})
+
+        instance.app = downstream
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message):
+            pass
+
+        anyio.run(
+            instance.__call__,
+            {"type": "http", "method": "POST", "path": "/", "headers": [], "query_string": b""},
+            receive,
+            send,
+        )
+
+        assert called["ran"] is True
+
+    def test_without_an_inner_app_raises(self):
+        instance = middleware()
+
+        async def receive():
+            return {"type": "http.request"}
+
+        async def send(message):
+            pass
+
+        with pytest.raises(RuntimeError, match="without an inner application"):
+            anyio.run(
+                instance.__call__,
+                {"type": "http", "path": "/x", "method": "GET", "headers": []},
+                receive,
+                send,
+            )

--- a/tests/test_security/test_middleware.py
+++ b/tests/test_security/test_middleware.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import anyio
+import pytest
+
 from sillo import SilloApp
 from sillo import json
 from sillo.core.http import HttpContext
@@ -176,3 +179,46 @@ def test_fail_closed_raises_on_backend_error():
     # fail_closed -> backend error propagates and is reported as a 500
     # (the app error handler converts the raised RuntimeError into a response).
     assert client.get("/").status_code == 500
+
+
+def test_a_non_config_object_is_rejected():
+    with pytest.raises(TypeError, match="must be a RateLimitConfig instance"):
+        RateLimitMiddleware(config="not-a-config")
+
+
+def test_non_http_scope_passes_through_untouched():
+    middleware = RateLimitMiddleware()
+    called = {}
+
+    async def downstream(scope, receive, send):
+        called["scope"] = scope
+
+    middleware.app = downstream
+
+    async def receive():
+        return {"type": "lifespan.startup"}
+
+    async def send(message):
+        pass
+
+    anyio.run(middleware.__call__, {"type": "lifespan"}, receive, send)
+
+    assert called["scope"] == {"type": "lifespan"}
+
+
+def test_without_an_inner_app_raises():
+    middleware = RateLimitMiddleware()
+
+    async def receive():
+        return {"type": "http.request"}
+
+    async def send(message):
+        pass
+
+    with pytest.raises(RuntimeError, match="without an inner application"):
+        anyio.run(
+            middleware.__call__,
+            {"type": "http", "path": "/x", "method": "GET", "headers": []},
+            receive,
+            send,
+        )

--- a/tests/test_sessions/test_middleware.py
+++ b/tests/test_sessions/test_middleware.py
@@ -74,7 +74,6 @@ class TestSessionMiddleware:
         assert "Set-Cookie" in response1.headers
         assert "test_session" in response1.headers["Set-Cookie"]
 
-    
     def test_file_session_middleware(self):
         """Test session middleware with file backend"""
         temp_dir = tempfile.mkdtemp()
@@ -109,7 +108,10 @@ class TestSessionMiddleware:
             assert response1.status_code == 200
             assert response1.json()["counter"] == 1
 
-            response2 = client.get("/file-session-test",headers = {"Cookie": response1.headers["Set-Cookie"]})
+            response2 = client.get(
+                "/file-session-test",
+                headers={"Cookie": response1.headers["Set-Cookie"]},
+            )
             assert response2.status_code == 200
             assert response2.json()["counter"] == 2
 
@@ -152,9 +154,7 @@ class TestSessionMiddleware:
             ctx.session["existing"] = "data"
             return json({"existing": ctx.session["existing"]})
 
-        app.use(
-            SessionMiddleware(config=SessionConfig(), secret_key="test-secret-key")
-        )
+        app.use(SessionMiddleware(config=SessionConfig(), secret_key="test-secret-key"))
 
         client = TestClient(app)
 
@@ -249,9 +249,7 @@ class TestSessionMiddleware:
             except Exception as e:
                 return json({"error": str(e)})
 
-        app.use(
-            SessionMiddleware(config=SessionConfig(), secret_key="test-secret-key")
-        )
+        app.use(SessionMiddleware(config=SessionConfig(), secret_key="test-secret-key"))
 
         client = TestClient(app)
 
@@ -280,7 +278,7 @@ class TestSessionMiddleware:
         assert response.status_code == 200
 
     async def test_persisting_without_a_session_is_a_noop(self):
-        """The post-phase is a no-op when dispatch never loaded a session."""
+        """persist_session() is a no-op when load_session() never ran."""
         middleware = SessionMiddleware(
             config=SessionConfig(), secret_key="test-secret-key"
         )
@@ -289,7 +287,7 @@ class TestSessionMiddleware:
             def __init__(self):
                 self.scope: dict = {}
 
-        result = await middleware._persist(DummyRequest(), None)
+        result = await middleware.persist_session(DummyRequest(), None)
         assert result is None
 
     def test_manager_given_as_class_raises_type_error(self):


### PR DESCRIPTION
Every built-in that was dispatch-form (BaseMiddleware + ASGIRequestResponseBridge) is now plain raw ASGI -- __init__(self, app=None, ...) and async def __call__(self, scope, receive, send) -- with its own named methods rather than a shared before/after contract:

- SessionMiddleware: load_session(ctx), persist_session(ctx, headers)
- AuthenticationMiddleware: authenticate(ctx)
- CORSMiddleware: check_request(ctx), apply_cors_headers(origin, headers)
- CSRFMiddleware: validate(ctx), set_token_cookie(ctx, headers)
- RateLimitMiddleware: check(ctx), set_limit_headers(headers, result)
- Shield: apply_security_headers(headers)
- NormalizeMiddleware: normalize(ctx)
- RequestIdMiddleware: assign_request_id(ctx), set_response_header(headers, id)
- ETagMiddleware: finish(ctx, start_message, body, send) -- buffers the body
- AcceptsMiddleware family: parse_accepts(ctx), apply_headers(...), negotiate(ctx)

sillo.middleware.response_headers.ResponseHeaders is a small shared utility (not a base class) that edits one outgoing ASGI message's headers with the same set_header/set_cookie/delete_cookie surface a response object offers, reusing BaseResponse's own methods rather than duplicating cookie serialization.

application.py: app.use()'s `raw` parameter now defaults to None and is inferred from the middleware's __call__ signature (arity/kind, not parameter names) rather than requiring raw=True everywhere. An already-constructed instance (how every built-in above is registered, e.g. app.use(SessionMiddleware(secret_key=...))) is recognised and has `.app` bound onto it directly instead of being re-constructed.

Bug fixes surfaced by the conversion:
- ETagMiddleware always hashed an empty body through the old dispatch bridge (_StreamingResponse.body was always b""), so every response got the same ETag regardless of content. Buffering the real bytes fixes this.
- Shield duplicated every header it didn't touch (set_headers() appended rather than replaced); now uses override_all=True.
- RateLimitMiddleware and AcceptsMiddleware stored per-request state on self, racy under concurrent requests; now request-local.
- StrictContentNegotiationMiddleware's negotiated values never reached the route handler (set on a ctx instance the router discards); now stored on ctx.state, which every HttpContext for the connection shares.

Docs (v1.0/advanced, v1.0/guides) updated to match: middleware.md's raw=True section and app.use() walkthrough, the security/session/auth/http-correctness references, and the guides that described the old dispatch-based internals.

5197 tests pass (11 new), 95% coverage, ruff + ty clean.