### PR TITLE
Match the most specific route first, not the first one registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`priority=` on routes.** `@app.get(..., priority=10)` (also on `Route(...)`, `add_route(...)`, and `ws_route(...)`) sets an explicit match-ordering weight. Routes are tried in descending priority, then by path specificity, then registration order. Raise it to force a route ahead of an overlapping one; use a negative value to make a route a deliberate fallback.
+- **`SilloApp(route_order=...)` / `Router(route_order=...)`.** `"specificity"` (the new default) or `"registration"` to restore the historical first-registered, first-matched behavior for a whole application. Documented in [Routing → Route matching order](https://sillo.build/v1.0/guides/routing/#route-matching-order).
+
+### Changed
+
+- **Overlapping routes now match most-specific-first, not registration-first.** A literal segment beats a parameter at the same position, a narrow converter (`:int`, `:float`, `:uuid`) beats a plain string parameter, and both beat a `:path` catch-all — decided left to right. `@app.get("/users/{id}")` no longer shadows a `@app.get("/users/me")` registered after it. The ordering is computed once, lazily, on the first request after registration, so per-request dispatch is unchanged. Pass `route_order="registration"` to opt out.
+
 ## [0.3.2.dev1] - 2026-09-07
 
 A development pre-release for testing. Install with `pip install --pre sillo-framework==0.3.2.dev1`.

--- a/docs/docs/src/content/docs/v1.0/advanced/routing.md
+++ b/docs/docs/src/content/docs/v1.0/advanced/routing.md
@@ -680,14 +680,24 @@ async def app(self, scope, receive, send):
 **Dispatch algorithm**:
 
 1. Build the middleware stack (outermost middleware first).
-2. Linear scan through `self.routes` in registration order.
-3. First `FULL` match → dispatch immediately (return).
-4. First `PARTIAL` match → record as the fallback, for its route params.
-5. **Every** `PARTIAL` match → union its methods into `allowed`.
-6. If no `FULL` match found, answer the fallback with a 405 built here.
-7. If no match at all → `NotFoundException` (HTTP) or close frame 4404 (WebSocket).
+2. On the first request after registration, order `self.routes` once by
+   `(-priority, specificity)` — a stable sort, so equal keys keep registration
+   order. Skipped when the router was built with `route_order="registration"`.
+3. Linear scan through `self.routes` in that order.
+4. First `FULL` match → dispatch immediately (return).
+5. First `PARTIAL` match → record as the fallback, for its route params.
+6. **Every** `PARTIAL` match → union its methods into `allowed`.
+7. If no `FULL` match found, answer the fallback with a 405 built here.
+8. If no match at all → `NotFoundException` (HTTP) or close frame 4404 (WebSocket).
 
-> **Important**: Route registration order matters. More specific routes should be registered before catch-all routes.
+**Specificity** is the tuple of per-segment ranks — `0` literal, `1` narrow
+converter (`int`/`float`/`uuid`/custom), `2` string parameter, `3` `:path` or
+regex — compared left to right, lower first. So `/users/me` (`(0, 0)`) is tried
+before `/users/{id}` (`(0, 2)`) whatever order they were registered in. An
+explicit `priority=` integer on a route overrides the computed order.
+
+> **Note**: With `route_order="registration"` (opt-in), registration order
+> matters and more specific routes must be registered before catch-all routes.
 
 #### Why the 405 is built here
 
@@ -1290,19 +1300,24 @@ This catches typos like `response_modle` and suggests `response_model`. The know
 
 ## 19. Common Pitfalls and Maintenance Notes
 
-### Pitfall 1: Route order matters
+### Pitfall 1: Route order
 
-Routes are matched in **registration order**. A catch-all `{path:path}` route registered first will shadow all subsequent routes.
+By default routes are matched **most-specific-first**, so a catch-all
+`{path:path}` route no longer shadows specific routes regardless of registration
+order:
 
 ```python
-# BAD: catch-all first
+# Both orders behave the same under the default route_order="specificity"
 router.get("/{path:path}", fallback)
-router.get("/users", list_users)  # Never reached!
-
-# GOOD: specific first
-router.get("/users", list_users)
-router.get("/{path:path}", fallback)
+router.get("/users", list_users)  # still reached
 ```
+
+Two cases still need care:
+
+- `route_order="registration"` (opt-in) restores the old behavior — then a
+  catch-all registered first *does* shadow everything after it.
+- When two routes are genuinely equally specific, the one registered first
+  wins. Use `priority=` to break the tie explicitly.
 
 ### Pitfall 2: Trailing slashes
 

--- a/docs/docs/src/content/docs/v1.0/guides/routing.mdx
+++ b/docs/docs/src/content/docs/v1.0/guides/routing.mdx
@@ -168,6 +168,7 @@ The `Route` constructor is used to define a route within the sillo application. 
 - **deprecated**: A boolean indicating whether the route is deprecated.
 - **parameters**: A list of additional OpenAPI parameters for the route.
 - **exclude_from_schema**: A boolean indicating whether to exclude the route from OpenAPI documentation.
+- **priority**: An integer match-ordering weight (default `0`). Routes are tried in descending priority, then by path specificity, then registration order. Raise it to force a route ahead of an overlapping one; lower it to make a route a fallback.
 - **kwargs**: Additional metadata for the route.
 
 ```text
@@ -187,6 +188,7 @@ Route(
     deprecated: bool = False,                     # Mark as deprecated
     parameters: List[Parameter] = [],             # Additional OpenAPI parameters
     exclude_from_schema: bool = False,            # Hide from OpenAPI docs
+    priority: int = 0,                            # Match-ordering weight
     **kwargs: Dict[str, Any]                      # Additional metadata
 )
 ```
@@ -327,9 +329,15 @@ Router(
     routes: Optional[List[Route]] = None,        # Initial routes to add
     tags: Optional[List[str]] = None,             # Default tags for all routes
     exclude_from_schema: bool = False,            # Hide all routes from docs
-    name: Optional[str] = None                    # Router name
+    name: Optional[str] = None,                   # Router name
+    route_order: str = "specificity",             # or "registration"
 )
 ```
+
+`route_order` controls how registered routes are ordered before matching.
+`"specificity"` (the default) tries the most specific path first regardless of
+registration order; `"registration"` keeps the historical first-registered,
+first-matched behavior. See [Route matching order](#route-matching-order).
 
 <Aside type="tip" title="HTTP Method Best Practices">
 
@@ -380,6 +388,59 @@ app = SilloApp()
 async def get_user(ctx: HttpContext, user_id: str):
     return {"id": user_id}
 ```
+
+##  Route matching order
+
+When more than one route can match a path, sillo picks the **most specific**
+one — not the one registered first. A literal segment beats a parameter at the
+same position, and a narrow converter (`:int`, `:float`, `:uuid`) beats a plain
+string parameter, which in turn beats a `:path` catch-all. The decision is made
+left to right, segment by segment.
+
+```py
+@app.get("/users/{user_id}")
+async def get_user(ctx: HttpContext, user_id: str):
+    return {"kind": "by-id", "user_id": user_id}
+
+@app.get("/users/me")          # declared later, still wins for /users/me
+async def get_me(ctx: HttpContext):
+    return {"kind": "me"}
+```
+
+`GET /users/me` hits `get_me`; `GET /users/42` hits `get_user`. Registration
+order no longer matters, so an early `/{slug}` route can't accidentally shadow a
+specific one added later.
+
+###  Forcing the order with `priority`
+
+Pass `priority=` (an integer, default `0`) to override the computed order.
+Higher priority is tried first; use a negative value to make a route a
+deliberate fallback.
+
+```py
+@app.get("/pages/{slug}", priority=-1)          # last resort
+async def page(ctx: HttpContext, slug: str):
+    return render_page(slug)
+
+@app.get("/pages/{slug:int}")                    # numeric ids handled first
+async def page_by_id(ctx: HttpContext, slug: int):
+    return page_from_db(slug)
+```
+
+`priority` is also accepted on `Route(...)`, `add_route(...)`, and
+`ws_route(...)`.
+
+###  Opting out
+
+To restore the historical "first registered, first matched" behavior for a
+whole application, pass `route_order="registration"`:
+
+```py
+app = SilloApp(route_order="registration")
+```
+
+Ordering is computed once, lazily, on the first request after routes are
+registered — it adds nothing to per-request dispatch.
 
 ##  Route Converters in sillo
 
@@ -1119,6 +1180,12 @@ app = SilloApp(debug=True)
 ```
 
 ##  Performance Considerations
+
+Routes are matched by a linear scan of compiled patterns, ordered so the most
+specific route comes first (see [Route matching order](#route-matching-order)).
+That ordering is computed **once**, lazily, on the first request after the last
+route is registered — repeated `add_route` calls at startup stay cheap, and
+per-request dispatch does no sorting or path inspection.
 
 ##  Route Grouping with `Group`
 

--- a/sillo/application.py
+++ b/sillo/application.py
@@ -364,6 +364,23 @@ class SilloApp:
                     their current behavior; recommended for new applications.
                 """),
         ] = False,
+        route_order: Annotated[
+            Literal["specificity", "registration"],
+            Doc("""
+                    How registered routes are ordered before matching.
+
+                    ``"specificity"`` (the default) sorts them so the most
+                    specific path always wins, whatever order they were
+                    registered in: a literal segment beats a parameter at the
+                    same position, so ``/users/me`` is matched before
+                    ``/users/{id}`` even when it is declared later. An explicit
+                    ``priority=`` on a route overrides the computed order.
+
+                    ``"registration"`` keeps the historical behavior — routes
+                    are tried in the order they were added, and an earlier
+                    dynamic route can shadow a later literal one.
+                """),
+        ] = "specificity",
         auth: Annotated[
             Sequence[AuthenticationBackend] | None,
             Doc("""
@@ -487,6 +504,7 @@ class SilloApp:
             dependencies=self.dependencies,
             route_class=self.route_class,
             strict_validation=strict_validation,
+            route_order=route_order,
         )
         self.exceptions_handler = ExceptionMiddleware()
         self.router = self.app
@@ -1193,6 +1211,7 @@ class SilloApp:
         | None = None,
         path: str | None = None,
         handler: WsHandlerType | None = None,
+        priority: int = 0,
     ) -> None:
         """
         Adds a WebSocket route to the application.
@@ -1225,7 +1244,7 @@ class SilloApp:
                 "path and handler are required when 'route' is not provided."
             )
 
-        self.router.add_ws_route(WebsocketRoute(path, handler))
+        self.router.add_ws_route(WebsocketRoute(path, handler, priority=priority))
 
     def add_command(self, command: type[Command]) -> type[Command]:
         """Register a console command on this application.
@@ -3043,6 +3062,13 @@ class SilloApp:
                     await websocket.send("Welcome to the chat!")
             """),
         ] = None,
+        priority: Annotated[
+            int,
+            Doc(
+                "Match-ordering weight. Tried in descending priority, then by "
+                "path specificity, then registration order. Defaults to 0."
+            ),
+        ] = 0,
     ):
         """
         Register a WebSocket route with the application.
@@ -3051,6 +3077,7 @@ class SilloApp:
             path (str): URL path pattern for the WebSocket route.
             handler (Callable): Async handler function for WebSocket connections.
                 Example: async def chat_handler(websocket, path): pass
+            priority (int): Match-ordering weight for the route. Defaults to 0.
 
         Returns:
             Callable: A decorator to register the WebSocket route.
@@ -3058,6 +3085,7 @@ class SilloApp:
         return self.router.ws_route(
             path=path,
             handler=handler,
+            priority=priority,
         )
 
     def __str__(self) -> str:

--- a/sillo/core/routing/_utils.py
+++ b/sillo/core/routing/_utils.py
@@ -54,9 +54,7 @@ def route_specificity(
     first. ``trailing_wildcard`` appends a catch-all rank, used for mounted
     sub-routers, which always consume an open-ended suffix.
     """
-    ranks = [
-        _segment_rank(s) for s in raw_path.strip("/").split("/") if s
-    ]
+    ranks = [_segment_rank(s) for s in raw_path.strip("/").split("/") if s]
     if trailing_wildcard:
         ranks.append(_RANK_WILDCARD)
     return tuple(ranks)

--- a/sillo/core/routing/_utils.py
+++ b/sillo/core/routing/_utils.py
@@ -1,6 +1,82 @@
+import re
 from enum import Enum
 
 from sillo.types import Scope
+
+# Path convertors whose regex is narrower than the default string segment
+# (`[^/]+`). A route that pins a segment to one of these is more specific
+# than one that accepts any string there, so it should be tried first.
+_TIGHT_CONVERTORS = frozenset({"int", "float", "uuid"})
+
+_SEGMENT_PARAM = re.compile(r"\{([a-zA-Z_]\w*)(?::([^}]+))?\}")
+
+# Per-segment specificity ranks. Lower is more specific.
+_RANK_LITERAL = 0
+_RANK_TIGHT_PARAM = 1
+_RANK_STRING_PARAM = 2
+_RANK_WILDCARD = 3
+
+
+def _segment_rank(segment: str) -> int:
+    """Rank one path segment by how tightly it constrains a match.
+
+    ``0`` a literal segment (``users``), ``1`` a parameter pinned to a narrow
+    convertor (``{id:int}``), ``2`` a plain string parameter (``{name}`` or
+    ``{name:str}``), ``3`` a catch-all — the ``path`` convertor, a regex
+    segment, or a segment that mixes a literal and a parameter.
+    """
+    if "{" not in segment:
+        return _RANK_LITERAL
+    match = _SEGMENT_PARAM.fullmatch(segment)
+    if match is None:
+        # `/v{n}` style or an unparseable regex segment — treat as loose.
+        return _RANK_WILDCARD
+    convertor = match.group(2)
+    if convertor is None or convertor == "str":
+        return _RANK_STRING_PARAM
+    if convertor in _TIGHT_CONVERTORS:
+        return _RANK_TIGHT_PARAM
+    if convertor == "path" or "." in convertor or "*" in convertor:
+        return _RANK_WILDCARD
+    # Any other named convertor is still a single narrowed segment.
+    return _RANK_TIGHT_PARAM
+
+
+def route_specificity(
+    raw_path: str, *, trailing_wildcard: bool = False
+) -> tuple[int, ...]:
+    """Build the match-ordering key for a route path.
+
+    The key is the tuple of per-segment ranks, compared lexicographically, so
+    a literal segment always beats a parameter at the same position and the
+    leftmost segment that differs decides. ``/users/me`` (``(0, 0)``) therefore
+    sorts ahead of ``/users/{id}`` (``(0, 2)``) no matter which was registered
+    first. ``trailing_wildcard`` appends a catch-all rank, used for mounted
+    sub-routers, which always consume an open-ended suffix.
+    """
+    ranks = [
+        _segment_rank(s) for s in raw_path.strip("/").split("/") if s
+    ]
+    if trailing_wildcard:
+        ranks.append(_RANK_WILDCARD)
+    return tuple(ranks)
+
+
+def route_order_key(route: object) -> tuple:
+    """Sort key that puts the most specific, highest-priority route first.
+
+    ``priority`` (an explicit integer, default ``0``) dominates; within the
+    same priority the specificity tuple decides; equal keys keep registration
+    order because the sort is stable.
+    """
+    priority = getattr(route, "priority", 0)
+    spec = getattr(route, "_specificity", None)
+    if spec is None:
+        trailing = type(route).__name__ == "Group"
+        spec = route_specificity(
+            getattr(route, "raw_path", ""), trailing_wildcard=trailing
+        )
+    return (-priority, spec)
 
 
 class MatchStatus(Enum):

--- a/sillo/core/routing/grouping.py
+++ b/sillo/core/routing/grouping.py
@@ -8,7 +8,7 @@ from sillo.objects import URLPath
 from sillo.route_builder import RouteBuilder
 from sillo.types import ASGIApp, Receive, Scope, Send
 
-from ._utils import MatchStatus, get_route_path
+from ._utils import MatchStatus, get_route_path, route_specificity
 from .base import BaseRoute
 
 
@@ -90,6 +90,10 @@ class Group(BaseRoute):
         self.pattern = self.route_info.pattern
         self.param_names = self.route_info.param_names
         self.route_type = self.route_info.route_type
+        # A mount always consumes an open-ended suffix, so it ranks after any
+        # literal route sharing its prefix but ahead of a looser parameter.
+        self.priority = 0
+        self._specificity = route_specificity(self.path, trailing_wildcard=True)
 
     @property
     def routes(self) -> list[BaseRoute]:

--- a/sillo/core/routing/router.py
+++ b/sillo/core/routing/router.py
@@ -54,7 +54,12 @@ from sillo.validation import (
     prefix_errors,
 )
 
-from ._utils import MatchStatus, get_route_path
+from ._utils import (
+    MatchStatus,
+    get_route_path,
+    route_order_key,
+    route_specificity,
+)
 from .base import BaseRoute, BaseRouter
 from .grouping import Group
 from .websocket import WebsocketRoute
@@ -233,6 +238,7 @@ class Route(BaseRoute):
         middleware: list[Any] | None = None,
         exclude_from_schema: bool = False,
         auth: Any | None = None,
+        priority: int = 0,
         **kwargs: Any,
     ) -> None:
         """Initialize a Route instance with full endpoint configuration.
@@ -297,6 +303,12 @@ class Route(BaseRoute):
                 OpenAPI documentation generation entirely.
             auth: Optional authentication gate instance for route-level
                 authentication and authorization checks.
+            priority: Explicit match-ordering weight. Routes are tried in
+                descending priority, then by path specificity (a literal
+                segment beats a parameter at the same position), then in
+                registration order. Raise it to force a route ahead of an
+                overlapping one, or lower it to make a route a deliberate
+                fallback. Defaults to ``0``.
             **kwargs: Additional metadata stored on the route instance
                 for use by plugins or custom extensions.
 
@@ -309,6 +321,10 @@ class Route(BaseRoute):
         if path == "":
             path = "/"
         self.raw_path = path
+        self.priority = priority
+        # Computed once here; read by the router when it orders its routes so
+        # request-time dispatch never inspects the path.
+        self._specificity = route_specificity(path)
         self.handler = handler
         self.auth = auth
         self.handler_signature = inspect.signature(handler)
@@ -792,6 +808,7 @@ class Router(BaseRouter):
         dependencies: list[Depend] | None = None,
         route_class: type[Route] = Route,
         strict_validation: bool = False,
+        route_order: Literal["specificity", "registration"] = "specificity",
     ):
         """Initialize the router with configuration options.
 
@@ -823,8 +840,20 @@ class Router(BaseRouter):
                 into full validation so bad input returns 422 rather than 500.
             route_class: The Route class to use when creating new routes
                 via decorator methods. Defaults to the standard Route class.
+            route_order: How registered routes are ordered before matching.
+                ``"specificity"`` (the default) sorts them so the most
+                specific path wins regardless of registration order — a
+                literal segment beats a parameter at the same position, and
+                an explicit ``priority=`` on a route overrides both.
+                ``"registration"`` keeps the historical first-registered,
+                first-matched behavior.
         """
         self.prefix = prefix or ""
+        self._route_order = route_order
+        # Routes are ordered lazily on the first request after any
+        # registration, so building an app stays append-only and the cost is
+        # paid once rather than per `add_route` call.
+        self._routes_sorted = False
         self.routes = list(routes)
         self.middleware: list[Middleware] = []
         self.sub_routers: dict[str, Router | ASGIApp] = {}
@@ -887,6 +916,19 @@ class Router(BaseRouter):
                 mounted_router = getattr(route, "_base_app", None)
                 if isinstance(mounted_router, Router):
                     mounted_router._set_inherited_dependencies(combined_dependencies)
+
+    def _order_routes(self) -> None:
+        """Order the route list so the most specific route matches first.
+
+        Run once, lazily, on the first request after any registration (see
+        ``_routes_sorted``). The sort is stable, so routes with an equal
+        ``(priority, specificity)`` key keep the order they were registered
+        in. With ``route_order="registration"`` this is a no-op and the
+        historical first-registered, first-matched behavior stands.
+        """
+        if self._route_order == "specificity":
+            self.routes.sort(key=route_order_key)
+        self._routes_sorted = True
 
     def _set_inherited_dependencies(
         self, inherited_dependencies: Sequence[Dependant]
@@ -1145,6 +1187,7 @@ class Router(BaseRouter):
 
         if not isinstance(route, Route):
             self.routes.append(route)
+            self._routes_sorted = False
             return
 
         if route.tags:
@@ -1156,6 +1199,7 @@ class Router(BaseRouter):
         route._router_dependants = list(self._get_combined_dependencies())
 
         self.routes.append(route)
+        self._routes_sorted = False
 
     def use(self, middleware: MiddlewareType) -> None:
         """Register a middleware component on this router.
@@ -2851,6 +2895,7 @@ class Router(BaseRouter):
         | None = None,
         path: str | None = None,
         handler: WsHandlerType | None = None,
+        priority: int = 0,
     ) -> None:
         """Add a WebSocket route to the application router.
 
@@ -2873,6 +2918,9 @@ class Router(BaseRouter):
             handler: The async WebSocket handler function. Required when
                 ``route`` is not provided. Must accept a single
                 ``WebSocketContext`` argument.
+            priority: Match-ordering weight for the route built from ``path``
+                and ``handler``. Ignored when a pre-constructed ``route`` is
+                passed. Defaults to ``0``.
 
         Returns:
             None. The route is appended to the router's internal route list.
@@ -2884,9 +2932,10 @@ class Router(BaseRouter):
         if route is not None:
             self.routes.append(route)
         elif path is not None and handler is not None:
-            self.routes.append(WebsocketRoute(path, handler))
+            self.routes.append(WebsocketRoute(path, handler, priority=priority))
         else:
             raise ValueError("Either route or both path and handler must be provided")
+        self._routes_sorted = False
 
     def ws_route(
         self,
@@ -2897,6 +2946,13 @@ class Router(BaseRouter):
             WsHandlerType | None,
             Doc("The WebSocket handler function. Must be an async function."),
         ] = None,
+        priority: Annotated[
+            int,
+            Doc(
+                "Match-ordering weight. Tried in descending priority, then by "
+                "path specificity, then registration order. Defaults to 0."
+            ),
+        ] = 0,
     ) -> Any:
         """Register a WebSocket route as a decorator or direct call.
 
@@ -2917,6 +2973,9 @@ class Router(BaseRouter):
             handler: Optional async WebSocket handler function. Must be a
                 coroutine function accepting a single ``WebSocketContext`` argument.
                 If provided the route is registered immediately.
+            priority: Match-ordering weight for the route. Tried in descending
+                priority, then by path specificity, then registration order.
+                Defaults to ``0``.
 
         Returns:
             The original handler function if handler was provided directly,
@@ -2929,7 +2988,9 @@ class Router(BaseRouter):
                 construction).
         """
         if handler:
-            return self.add_ws_route(WebsocketRoute(path, handler))
+            return self.add_ws_route(
+                WebsocketRoute(path, handler, priority=priority)
+            )
 
         def decorator(handler: WsHandlerType) -> WsHandlerType:
             """Create a WebSocket route from the handler and register it.
@@ -2948,7 +3009,7 @@ class Router(BaseRouter):
                 The original handler function, unmodified, allowing it to
                 be referenced directly outside of the routing context.
             """
-            self.add_ws_route(WebsocketRoute(path, handler))
+            self.add_ws_route(WebsocketRoute(path, handler, priority=priority))
             return handler
 
         return decorator
@@ -3170,6 +3231,9 @@ class Router(BaseRouter):
         """
         scope["app"] = self
 
+        if not self._routes_sorted:
+            self._order_routes()
+
         path_match = None
         path_match_params: dict[str, Any] = {}
         # Every method the path supports, not just the first route to claim
@@ -3232,6 +3296,7 @@ class Router(BaseRouter):
         app._set_inherited_dependencies(self._get_combined_dependencies())
         path = app.prefix
         self.routes.append(Group(app=app, path=path, name=name))
+        self._routes_sorted = False
 
     def get_all_routes(self) -> list[Route]:
         """Collect all HTTP routes from this router and all nested sub-routers.

--- a/sillo/core/routing/router.py
+++ b/sillo/core/routing/router.py
@@ -2988,9 +2988,7 @@ class Router(BaseRouter):
                 construction).
         """
         if handler:
-            return self.add_ws_route(
-                WebsocketRoute(path, handler, priority=priority)
-            )
+            return self.add_ws_route(WebsocketRoute(path, handler, priority=priority))
 
         def decorator(handler: WsHandlerType) -> WsHandlerType:
             """Create a WebSocket route from the handler and register it.

--- a/sillo/core/routing/websocket.py
+++ b/sillo/core/routing/websocket.py
@@ -16,7 +16,7 @@ from sillo.types import (
 from sillo.websockets import WebSocketContext
 from sillo.websockets.errors import WebSocketErrorMiddleware
 
-from ._utils import MatchStatus, get_route_path
+from ._utils import MatchStatus, get_route_path, route_specificity
 from .base import BaseRoute
 
 if TYPE_CHECKING:
@@ -143,6 +143,14 @@ class WebsocketRoute(BaseRoute):
                 - websocket.close(): Close the connection
                 """),
         ],
+        priority: Annotated[
+            int,
+            Doc("""
+                Explicit match-ordering weight. WebSocket routes are tried in
+                descending priority, then by path specificity, then in
+                registration order. Defaults to ``0``.
+                """),
+        ] = 0,
     ):
         """Initialize a WebSocket route with path pattern and handler.
 
@@ -174,6 +182,8 @@ class WebsocketRoute(BaseRoute):
         assert callable(handler), "Route handler must be callable"
         assert inspect.iscoroutinefunction(handler), "Route handler must be async"
         self.raw_path = path
+        self.priority = priority
+        self._specificity = route_specificity(path)
         self.handler: WsHandlerType = handler
         self.dependant: Dependant = get_dependant(handler)
         self.route_info = RouteBuilder.create_pattern(path)

--- a/tests/test_routing/test_route_ordering.py
+++ b/tests/test_routing/test_route_ordering.py
@@ -7,6 +7,8 @@ now orders routes by path specificity before matching, with an explicit
 ``route_order="registration"`` to opt back into the historical behavior.
 """
 
+from types import SimpleNamespace
+
 import pytest
 
 from sillo import SilloApp, json, text
@@ -48,6 +50,14 @@ def test_specificity_mixed_literal_and_param_segment_is_loose():
     assert route_specificity("/v{n}/users") > route_specificity("/{x}/users")
 
 
+def test_specificity_named_convertor_ranks_as_tight_param():
+    # a registered non-str convertor (`slug`) narrows the segment, so it ranks
+    # ahead of a plain string parameter and behind a literal
+    assert route_specificity("/p/me") < route_specificity("/p/{s:slug}")
+    assert route_specificity("/p/{s:slug}") < route_specificity("/p/{s}")
+    assert route_specificity("/p/{s:slug}") < route_specificity("/p/{s:path}")
+
+
 # ========== route_order_key ==========
 
 
@@ -59,6 +69,18 @@ def test_order_key_priority_dominates_specificity():
     dynamic_high = Route("/users/{id}", h, methods=["GET"], priority=10)
 
     assert route_order_key(dynamic_high) < route_order_key(literal)
+
+
+def test_order_key_falls_back_to_raw_path_without_cached_specificity():
+    # a bare BaseRoute-like object that never computed `_specificity`
+    plain = SimpleNamespace(raw_path="/a/b")
+    assert route_order_key(plain) == (0, (0, 0))
+
+    # a class literally named "Group" triggers the implicit trailing wildcard
+    class Group:
+        raw_path = "/a"
+
+    assert route_order_key(Group()) == (0, (0, 3))
 
 
 # ========== end-to-end dispatch ==========

--- a/tests/test_routing/test_route_ordering.py
+++ b/tests/test_routing/test_route_ordering.py
@@ -1,0 +1,270 @@
+"""Tests for specificity-based route ordering and the ``priority=`` override.
+
+A dynamic route registered before an overlapping literal one used to shadow
+it — ``/users/{id}`` declared first would swallow ``/users/me``. The router
+now orders routes by path specificity before matching, with an explicit
+``priority=`` weight on a route as the manual override, and
+``route_order="registration"`` to opt back into the historical behavior.
+"""
+
+import pytest
+
+from sillo import SilloApp, json, text
+from sillo.core.http import HttpContext
+from sillo.core.routing import Route, Router
+from sillo.core.routing._utils import route_order_key, route_specificity
+from sillo.testclient import TestClient
+
+# ========== route_specificity unit tests ==========
+
+
+def test_specificity_literal_beats_parameter():
+    assert route_specificity("/users/me") < route_specificity("/users/{id}")
+
+
+def test_specificity_tight_convertor_beats_string_parameter():
+    assert route_specificity("/users/{id:int}") < route_specificity("/users/{id}")
+    assert route_specificity("/users/{id:int}") < route_specificity("/users/{id:str}")
+
+
+def test_specificity_string_parameter_beats_wildcard():
+    assert route_specificity("/files/{name}") < route_specificity("/files/{path:path}")
+
+
+def test_specificity_leftmost_segment_decides():
+    # literal at position 2 beats a parameter at position 2, regardless of
+    # what sits further right
+    assert route_specificity("/a/b/{y}") < route_specificity("/a/{x}/c")
+
+
+def test_specificity_literal_prefix_beats_bare_mount():
+    assert route_specificity("/api/health") < route_specificity(
+        "/api", trailing_wildcard=True
+    )
+
+
+def test_specificity_mixed_literal_and_param_segment_is_loose():
+    # `/v{n}` cannot be parsed as a clean parameter segment -> treated as loose
+    assert route_specificity("/v{n}/users") > route_specificity("/{x}/users")
+
+
+# ========== route_order_key ==========
+
+
+def test_order_key_priority_dominates_specificity():
+    async def h(ctx: HttpContext):
+        return text("ok")
+
+    literal = Route("/users/me", h, methods=["GET"])
+    dynamic_high = Route("/users/{id}", h, methods=["GET"], priority=10)
+
+    assert route_order_key(dynamic_high) < route_order_key(literal)
+
+
+# ========== end-to-end dispatch ==========
+
+
+def test_literal_wins_when_registered_after_dynamic():
+    app = SilloApp()
+
+    @app.get("/users/{user_id}")
+    async def get_user(ctx: HttpContext, user_id: str):
+        return json({"kind": "dynamic", "user_id": user_id})
+
+    @app.get("/users/me")
+    async def get_me(ctx: HttpContext):
+        return json({"kind": "me"})
+
+    client = TestClient(app)
+    assert client.get("/users/me").json() == {"kind": "me"}
+    assert client.get("/users/42").json() == {"kind": "dynamic", "user_id": "42"}
+
+
+def test_tight_convertor_wins_over_string_parameter():
+    app = SilloApp()
+
+    @app.get("/items/{name}")
+    async def by_name(ctx: HttpContext, name: str):
+        return json({"kind": "name", "name": name})
+
+    @app.get("/items/{item_id:int}")
+    async def by_id(ctx: HttpContext, item_id: int):
+        return json({"kind": "id", "item_id": item_id})
+
+    client = TestClient(app)
+    assert client.get("/items/7").json() == {"kind": "id", "item_id": 7}
+    assert client.get("/items/socks").json() == {"kind": "name", "name": "socks"}
+
+
+def test_priority_forces_a_route_ahead():
+    app = SilloApp()
+
+    @app.get("/things/special", priority=-10)
+    async def demoted(ctx: HttpContext):
+        return json({"kind": "literal-demoted"})
+
+    @app.get("/things/{slug}", priority=10)
+    async def promoted(ctx: HttpContext, slug: str):
+        return json({"kind": "dynamic-promoted", "slug": slug})
+
+    client = TestClient(app)
+    # the parameter route was pushed ahead of the literal one on purpose
+    assert client.get("/things/special").json() == {
+        "kind": "dynamic-promoted",
+        "slug": "special",
+    }
+
+
+def test_priority_as_deliberate_fallback():
+    app = SilloApp()
+
+    @app.get("/pages/{slug}", priority=-1)
+    async def catch_all(ctx: HttpContext, slug: str):
+        return json({"kind": "fallback", "slug": slug})
+
+    @app.get("/pages/{slug:int}")
+    async def by_number(ctx: HttpContext, slug: int):
+        return json({"kind": "numbered", "slug": slug})
+
+    client = TestClient(app)
+    assert client.get("/pages/12").json() == {"kind": "numbered", "slug": 12}
+    assert client.get("/pages/about").json() == {"kind": "fallback", "slug": "about"}
+
+
+def test_registration_order_mode_preserves_historical_shadowing():
+    app = SilloApp(route_order="registration")
+
+    @app.get("/users/{user_id}")
+    async def get_user(ctx: HttpContext, user_id: str):
+        return json({"kind": "dynamic", "user_id": user_id})
+
+    @app.get("/users/me")
+    async def get_me(ctx: HttpContext):
+        return json({"kind": "me"})
+
+    client = TestClient(app)
+    # the earlier dynamic route still swallows the later literal one
+    assert client.get("/users/me").json() == {"kind": "dynamic", "user_id": "me"}
+
+
+def test_equal_specificity_keeps_registration_order():
+    app = SilloApp()
+
+    @app.get("/a/{x}")
+    async def first(ctx: HttpContext, x: str):
+        return json({"which": "first", "x": x})
+
+    @app.get("/b/{y}")
+    async def second(ctx: HttpContext, y: str):
+        return json({"which": "second", "y": y})
+
+    order = [r.raw_path for r in app.router.routes if isinstance(r, Route)]
+    # dispatch once so the lazy ordering runs
+    TestClient(app).get("/a/1")
+    assert [r.raw_path for r in app.router.routes if isinstance(r, Route)] == order
+
+
+def test_ordering_is_lazy_and_runs_once():
+    router = Router()
+
+    async def h(ctx: HttpContext):
+        return text("ok")
+
+    router.add_route(Route("/{slug}", h, methods=["GET"]))
+    assert router._routes_sorted is False
+
+    router.add_route(Route("/home", h, methods=["GET"]))
+    assert router._routes_sorted is False
+
+    router._order_routes()
+    assert router._routes_sorted is True
+    assert router.routes[0].raw_path == "/home"
+
+    # a later registration re-arms the lazy sort
+    router.add_route(Route("/about", h, methods=["GET"]))
+    assert router._routes_sorted is False
+
+
+def test_405_allow_header_still_spans_every_matching_route():
+    app = SilloApp()
+
+    @app.post("/reports/{report_id}")
+    async def update_report(ctx: HttpContext, report_id: str):
+        return json({"updated": report_id})
+
+    @app.get("/reports/summary")
+    async def report_summary(ctx: HttpContext):
+        return json({"kind": "summary"})
+
+    client = TestClient(app)
+    # DELETE matches neither method; the path is claimed by both the literal
+    # and the parameter route, and `Allow` must name every method they permit.
+    resp = client.delete("/reports/summary")
+    assert resp.status_code == 405
+    allow = {m.strip() for m in resp.headers["allow"].split(",")}
+    assert {"GET", "POST"} <= allow
+
+
+def test_websocket_routes_are_ordered_by_specificity_too():
+    from sillo.websockets import WebSocketContext
+
+    app = SilloApp()
+
+    @app.ws_route("/ws/{room}")
+    async def any_room(websocket: WebSocketContext, room: str):
+        await websocket.accept()
+        await websocket.send_json({"kind": "dynamic", "room": room})
+        await websocket.close()
+
+    @app.ws_route("/ws/lobby")
+    async def lobby(websocket: WebSocketContext):
+        await websocket.accept()
+        await websocket.send_json({"kind": "lobby"})
+        await websocket.close()
+
+    client = TestClient(app)
+    with client.websocket_connect("/ws/lobby") as ws:
+        assert ws.receive_json() == {"kind": "lobby"}
+    with client.websocket_connect("/ws/other") as ws:
+        assert ws.receive_json() == {"kind": "dynamic", "room": "other"}
+
+
+def test_websocket_priority_override():
+    from sillo.websockets import WebSocketContext
+
+    app = SilloApp()
+
+    @app.ws_route("/ws/lobby", priority=-10)
+    async def lobby(websocket: WebSocketContext):
+        await websocket.accept()
+        await websocket.send_json({"kind": "literal-demoted"})
+        await websocket.close()
+
+    @app.ws_route("/ws/{room}", priority=10)
+    async def any_room(websocket: WebSocketContext, room: str):
+        await websocket.accept()
+        await websocket.send_json({"kind": "dynamic-promoted", "room": room})
+        await websocket.close()
+
+    client = TestClient(app)
+    with client.websocket_connect("/ws/lobby") as ws:
+        assert ws.receive_json() == {"kind": "dynamic-promoted", "room": "lobby"}
+
+
+def test_specificity_ordering_across_mounted_router():
+    app = SilloApp()
+    api = Router(prefix="/api")
+
+    @api.get("/health")
+    async def health(ctx: HttpContext):
+        return json({"kind": "mounted-health"})
+
+    @app.get("/api/health/raw")
+    async def raw_health(ctx: HttpContext):
+        return json({"kind": "literal-raw"})
+
+    app.mount_router(api)
+
+    client = TestClient(app)
+    assert client.get("/api/health").json() == {"kind": "mounted-health"}
+    assert client.get("/api/health/raw").json() == {"kind": "literal-raw"}


### PR DESCRIPTION
## What

Overlapping routes now match **most-specific-first** instead of first-registered-first. `@app.get("/users/{id}")` no longer shadows a `@app.get("/users/me")` declared after it.

Specificity is the tuple of per-segment ranks, compared left to right:

| rank | segment |
|---|---|
| 0 | literal (`users`) |
| 1 | narrow converter (`{id:int}`, `{id:float}`, `{id:uuid}`, custom) |
| 2 | string parameter (`{name}`, `{name:str}`) |
| 3 | `:path` / regex catch-all |

So `/users/me` → `(0, 0)` beats `/users/{id}` → `(0, 2)`.

## New knobs

- **`priority=<int>`** on `Route(...)`, `add_route(...)`, the verb decorators (via `**kwargs`), and `ws_route(...)`. Sort key is `(-priority, specificity)`. Raise it to force a route ahead of an overlapping one; use a negative value for a deliberate fallback.
- **`SilloApp(route_order="registration")`** / **`Router(route_order="registration")`** restores the historical first-registered, first-matched behavior.

## Performance

Ordering runs **once**, lazily, on the first request after the last registration (`_routes_sorted` flag, re-armed on every `add_route`/`add_ws_route`/`mount_router`). The sort is stable, so equal-key routes keep registration order. Per-request dispatch is unchanged — no sort, no `inspect`, no path parsing. Each route's specificity tuple is precomputed at construction (`_specificity`), including `WebsocketRoute` and mounted `Group`s (which carry an implicit trailing wildcard so a bare mount ranks after literal siblings).

## Behavior change

This changes matching for apps that today rely on registering a dynamic/catch-all route *before* a more specific one. Those apps set `route_order="registration"` to keep the old behavior. Apps that registered specific-before-general (the documented recommendation) are unaffected. CHANGELOG updated under `[Unreleased]`.

## Tests

`tests/test_routing/test_route_ordering.py` — 18 cases: the `route_specificity` key, `route_order_key` priority dominance, end-to-end literal-vs-dynamic and tight-converter-vs-string dispatch, `priority=` override and fallback, `route_order="registration"` escape hatch, stable order for equal specificity, lazy-sort-runs-once, 405 `Allow` header still spans every matching route, ordering across a mounted router, and WebSocket parity (specificity + `priority=`).

Full suite: **5270 passed**, 60 skipped. `ruff` clean; `mypy` adds no new errors.

## Docs

- `guides/routing.mdx`: new "Route matching order" section, `priority` / `route_order` in the constructor references, note in Performance Considerations.
- `advanced/routing.md`: dispatch algorithm updated, "Pitfall 1: Route order" rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)