### PR TITLE
Silence ty on the Unix-only os.*xattr calls

### DIFF
--- a/sillo/storage/drivers/local.py
+++ b/sillo/storage/drivers/local.py
@@ -332,7 +332,7 @@ def _remember_type(staging: Path, target: Path, content_type: str) -> None:
         content_type: What it will be served as.
     """
     try:
-        os.setxattr(staging, XATTR, content_type.encode())  # type: ignore[attr-defined]
+        os.setxattr(staging, XATTR, content_type.encode())  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         return
     except (AttributeError, OSError):
         # No extended attributes here — a different filesystem, or a platform
@@ -353,7 +353,7 @@ def _recall_type(path: Path) -> str:
         What it was stored as, or the neutral fallback.
     """
     try:
-        return os.getxattr(path, XATTR).decode()  # type: ignore[attr-defined]
+        return os.getxattr(path, XATTR).decode()  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
     except (AttributeError, OSError):
         pass
 
@@ -400,7 +400,7 @@ def _xattrs_work(root: Path) -> bool:
     probe = root / ".sillo-xattr-probe"
     try:
         probe.touch()
-        os.setxattr(probe, XATTR, b"probe")  # type: ignore[attr-defined]
+        os.setxattr(probe, XATTR, b"probe")  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
         return True
     except (AttributeError, OSError):
         return False


### PR DESCRIPTION
## What

`ty check sillo` reports three `unresolved-attribute` errors for `os.getxattr` / `os.setxattr` in `sillo/storage/drivers/local.py`:

```
error[unresolved-attribute]: Module `os` has no member `setxattr`   --> local.py:335
error[unresolved-attribute]: Module `os` has no member `getxattr`   --> local.py:356
error[unresolved-attribute]: Module `os` has no member `setxattr`   --> local.py:403
```

These members exist only on Unix; ty resolves stdlib against Python 3.10 with no platform assumption. The code already guards every call with `except (AttributeError, OSError)`, and the lines already carried `# type: ignore[attr-defined]` for mypy.

## Change

Append `# ty: ignore[unresolved-attribute]` to each of the three lines, keeping the mypy ignore — the `# type: ignore[...]  # ty: ignore[...]` form already used in `sillo/application.py:67`.

Comment-only. `ty check sillo` → **All checks passed**; `ruff` clean; storage tests: 237 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)