### PR TITLE
Drop the traceback from 404 responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Overlapping routes now match most-specific-first, not registration-first.** A literal segment beats a parameter at the same position, a narrow converter (`:int`, `:float`, `:uuid`) beats a plain string parameter, and both beat a `:path` catch-all — decided left to right. `@app.get("/users/{id}")` no longer shadows a `@app.get("/users/me")` registered after it. The ordering is computed once, lazily, on the first request after registration, so per-request dispatch is unchanged. Pass `route_order="registration"` to opt out.
+- **A 404 response no longer carries a traceback.** The stack of `raise NotFoundException` is the router's, not the caller's — it named internal framework paths and told a developer nothing about their own code. Debug mode still widens the *message* (the exception's `detail` instead of the generic sentence); it no longer adds a `traceback` field.
 
 ## [0.3.2.dev1] - 2026-09-07
 

--- a/sillo/handlers/not_found.py
+++ b/sillo/handlers/not_found.py
@@ -1,5 +1,4 @@
 import http
-import traceback
 import typing
 
 from sillo.core.http import HttpContext
@@ -73,10 +72,12 @@ async def handle_404_error(
     the header expresses no preference, which is the right default for an API.
 
     How much detail the body carries depends on the application's ``debug``
-    flag, read from ``ctx.app``. With debug on, the exception's own
-    ``detail`` is returned along with a traceback; with debug off — and when
-    the flag cannot be read at all — a generic message is returned instead, so
-    a misconfigured application errs towards saying less rather than more.
+    flag, read from ``ctx.app``. With debug on, the exception's own ``detail``
+    is returned; with debug off — and when the flag cannot be read at all — a
+    generic message is returned instead, so a misconfigured application errs
+    towards saying less rather than more. A 404 never carries a traceback:
+    the stack of ``raise NotFoundException`` inside the router describes the
+    framework, not the caller's code, and it would disclose internal paths.
 
     Args:
         ctx: The context for the request, used for the application's debug
@@ -89,15 +90,7 @@ async def handle_404_error(
         text according to what the client asked for.
     """
     debug = _debug_enabled(ctx)
-
-    if debug:
-        error_message = exception.detail
-        traceback_info = traceback.format_exc()
-        if traceback_info.strip() == "NoneType: None":
-            traceback_info = None
-    else:
-        error_message = GENERIC_MESSAGE
-        traceback_info = None
+    error_message = exception.detail if debug else GENERIC_MESSAGE
 
     if _prefers_html(ctx):
         return html(
@@ -110,8 +103,6 @@ async def handle_404_error(
             "error": http.HTTPStatus(404).phrase,
             "message": error_message,
         }
-        if traceback_info:
-            error_details["traceback"] = traceback_info
         return json(error_details, status_code=404)
 
     return text(f"404 - Not Found\n{error_message}", status_code=404)

--- a/tests/test_exception_handlers/test_not_found_handler.py
+++ b/tests/test_exception_handlers/test_not_found_handler.py
@@ -9,8 +9,7 @@ every 404 in every deployment answered as though debug were on.
 
 import pytest
 
-from sillo import SilloApp
-from sillo import text
+from sillo import SilloApp, text
 from sillo.handlers.not_found import GENERIC_MESSAGE
 from sillo.testclient import TestClient
 
@@ -92,14 +91,20 @@ def test_debug_returns_the_exception_detail(development):
     assert message != GENERIC_MESSAGE
 
 
-def test_debug_includes_a_traceback(development):
-    assert "traceback" in development.get("/missing", headers=API).json()
+def test_debug_still_never_includes_a_traceback(development):
+    """A 404 is not a crash: the stack of ``raise NotFoundException`` is the
+    router's, not the caller's, and it discloses internal paths. Debug mode
+    widens the *message*, never adds a traceback."""
+    body = development.get("/missing", headers=API).json()
+    assert "traceback" not in body
 
 
 def test_the_flag_is_read_from_the_application_not_assumed():
     """Both settings are honoured; neither is hard-coded."""
     on = TestClient(SilloApp(debug=True)).get("/missing", headers=API).json()["message"]
-    off = TestClient(SilloApp(debug=False)).get("/missing", headers=API).json()["message"]
+    off = (
+        TestClient(SilloApp(debug=False)).get("/missing", headers=API).json()["message"]
+    )
 
     assert on != off
     assert off == GENERIC_MESSAGE


### PR DESCRIPTION
## What

A JSON 404 in debug mode used to include a `traceback` field:

```json
{"status":404,"error":"Not Found","message":"Not Found",
 "traceback":"Traceback (most recent call last):\n  File \"/…/sillo/core/routing/router.py\", line 3299…"}
```

That stack is the router's `raise NotFoundException`, not the caller's code — it tells a developer nothing about their app and it prints sillo's install path into the response body.

## Change

`sillo/handlers/not_found.py`: remove the `traceback.format_exc()` capture and the `traceback` key. Debug mode still widens the **message** (the exception's `detail` instead of the generic sentence); it just no longer carries a traceback. `import traceback` dropped.

Unhandled 500s in debug are untouched — a crash *is* the caller's stack and worth showing.

## Tests

`test_debug_includes_a_traceback` → `test_debug_still_never_includes_a_traceback`. Full exception-handler suite: 99 passed; the 404/exception slice across the repo: 178 passed. `ruff` + `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)