### PR TITLE
docs: scope the dev notice to the intro page, add a dev flag by the logo

### DIFF
--- a/docs/docs/src/components/Header.astro
+++ b/docs/docs/src/components/Header.astro
@@ -12,11 +12,17 @@
  * lives under `components/overrides/parts/`, which the package does not
  * export, so a deep import would fail to resolve at build time. It is a
  * button targeting the `drawer` popover that PageFrame renders.
+ *
+ * The "dev" flag beside the logo is the one place that marks every page of a
+ * `preview` version (see `versions.mjs`) as unreleased — the notice in
+ * `MarkdownContent.astro` only repeats that in full on the manual's front
+ * door, so this is what a reader still sees on page two.
  */
 import Search from 'lucode-starlight/components/overrides/Search.astro';
 import SiteTitle from 'lucode-starlight/components/overrides/SiteTitle.astro';
 import config from 'virtual:starlight/user-config';
 import SectionNav from './SectionNav.astro';
+import { routeParts } from '../versions.mjs';
 
 const GITHUB = 'https://github.com/sillohq/core';
 const INSTALL = 'uv add sillo-framework';
@@ -25,6 +31,11 @@ const INSTALL = 'uv add sillo-framework';
 const shouldRenderSearch =
     config.pagefind ||
     config.components.Search !== '@astrojs/starlight/components/Search.astro';
+
+const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
+const pathname = Astro.url.pathname;
+const withoutBase = BASE && pathname.startsWith(BASE) ? pathname.slice(BASE.length) : pathname;
+const { version } = routeParts(withoutBase);
 ---
 
 <div class="header-shell">
@@ -44,6 +55,7 @@ const shouldRenderSearch =
             </svg>
         </button>
         <SiteTitle />
+        {version?.preview && <span class="dev-flag">dev</span>}
     </div>
 
     <div class="header-search">
@@ -126,6 +138,19 @@ const shouldRenderSearch =
         max-height: 1.6rem;
         width: auto;
         max-width: none;
+    }
+
+    /* Marks a `preview` version (see `versions.mjs`) beside the logo — the
+       one flag that follows a reader across every page of that version. */
+    .dev-flag {
+        padding-inline: calc(var(--spacing) * 1);
+        border-radius: calc(var(--spacing) * 0.75);
+        background: color-mix(in oklab, var(--foreground) 10%, transparent);
+        font-size: 0.5625rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--muted-foreground);
     }
 
     .header-search {
@@ -349,7 +374,8 @@ const shouldRenderSearch =
             justify-self: auto;
         }
 
-        .header-left :global(.site-title) {
+        .header-left :global(.site-title),
+        .header-left .dev-flag {
             display: none;
         }
 

--- a/docs/docs/src/components/MarkdownContent.astro
+++ b/docs/docs/src/components/MarkdownContent.astro
@@ -4,11 +4,13 @@
  * theme's own MarkdownContent.
  *
  * A version marked `preview` in src/versions.mjs documents code that is not on
- * PyPI yet, so every page in it has to say so — someone arriving from a search
- * result has no other signal that the snippet in front of them will not run
- * against their install. Doing it here rather than in each page's frontmatter
- * means it cannot be forgotten on a new page, and it comes back off on its own
- * the day the version stops being a preview.
+ * PyPI yet. The notice used to repeat on every page of that version, which
+ * turned into noise once the manual had more than a couple of pages — so it
+ * now shows once, on the manual's own front door (the "first intro page"),
+ * which is where someone arrives from the switcher or a bare `/v1.0/` link
+ * and has not seen it yet. The "dev" flag beside the logo in the nav (see
+ * `Header.astro`) is what keeps the rest of the pages honest about the
+ * version without repeating the full notice on each one.
  *
  * It sits inside MarkdownContent rather than above the title because this is
  * the one wrapper that renders exactly once per page, on every template.
@@ -17,20 +19,22 @@ import ThemeMarkdownContent from 'lucode-starlight/components/overrides/Markdown
 import { VERSIONS, DEFAULT_VERSION, routeParts } from '../versions.mjs';
 
 const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
+const INTRO_PAGE = 'guides/introduction/';
 
 const pathname = Astro.url.pathname;
 const withoutBase = BASE && pathname.startsWith(BASE) ? pathname.slice(BASE.length) : pathname;
 const { version, rest } = routeParts(withoutBase);
+const isIntroPage = rest === INTRO_PAGE;
 
 const stable = VERSIONS.find((entry) => entry.slug === DEFAULT_VERSION);
 /* The same page in the released version, which is what someone who landed here
    by accident actually wanted. */
-const stableHref = `${BASE}/${DEFAULT_VERSION}/${rest || 'guides/introduction/'}`;
+const stableHref = `${BASE}/${DEFAULT_VERSION}/${rest || INTRO_PAGE}`;
 ---
 
 <ThemeMarkdownContent>
     {
-        version?.preview && (
+        version?.preview && isIntroPage && (
             <aside class="version-notice" aria-label="Version notice">
                 <p>
                     This is the <strong>{version.label}</strong> documentation, for a release that

--- a/docs/docs/src/components/VersionSwitcher.astro
+++ b/docs/docs/src/components/VersionSwitcher.astro
@@ -57,7 +57,6 @@ const targets = VERSIONS.map((entry) => {
         <span class="cap">Version</span>
         <span class="now">
             {current.label}
-            {current.preview && <span class="flag">dev</span>}
         </span>
         <svg class="chev" viewBox="0 0 16 16" aria-hidden="true"
             ><path d="m4.5 6.5 3.5 3.5 3.5-3.5"></path></svg
@@ -122,18 +121,6 @@ const targets = VERSIONS.map((entry) => {
         font-weight: 600;
         font-variant-numeric: tabular-nums;
         color: var(--foreground);
-    }
-
-    /* Marks a version with no release yet — see `preview` in src/versions.mjs. */
-    .flag {
-        padding-inline: calc(var(--spacing) * 1);
-        border-radius: calc(var(--spacing) * 0.75);
-        background: color-mix(in oklab, var(--foreground) 10%, transparent);
-        font-size: 0.5625rem;
-        font-weight: 600;
-        letter-spacing: 0.04em;
-        text-transform: uppercase;
-        color: var(--muted-foreground);
     }
 
     .chev {

--- a/docs/docs/src/versions.mjs
+++ b/docs/docs/src/versions.mjs
@@ -26,8 +26,10 @@ import { join } from 'node:path';
  * @property {string} slug   First URL segment, and the content directory name.
  * @property {string} label  What the switcher shows.
  * @property {string} [note] A short qualifier beside the label in the menu.
- * @property {boolean} [preview] Renders the "in development" treatment and
- *   puts a banner at the top of every page in the version.
+ * @property {boolean} [preview] Renders the "in development" treatment: a
+ *   "dev" flag beside the logo in the nav on every page (`Header.astro`),
+ *   and the full unreleased-version notice on the manual's front door only
+ *   (`MarkdownContent.astro`).
  */
 
 /** @type {DocsVersion[]} */


### PR DESCRIPTION
## Summary

- The v1.0 (`preview`) "in development" notice previously repeated on **every** page of the manual — noise once a manual has more than a couple of pages. It now renders **only on the intro page** (`guides/introduction/`), the front door someone actually lands on from the version switcher or a bare `/v1.0/` link.
- A small **"dev" flag now sits beside the logo in the nav header**, on every page of a preview version — a constant, low-noise reminder that the rest of the manual doesn't need the full notice repeated.
- Removed the old "dev" flag that lived inside the version switcher's own summary, so there's one flag (by the logo) instead of two.

## Verified

- `bun run build` — 526 pages built clean.
- `dist/v1.0/guides/introduction/index.html` contains the full notice; any other `v1.0` page (checked `guides/routing/`) does not.
- Both pages carry the `dev-flag` beside the logo; a `v0.x` page does not.
- The version switcher no longer emits the old inline flag span.

🤖 Generated with [Claude Code](https://claude.com/claude-code)